### PR TITLE
replace partially-managed experience and places with import command

### DIFF
--- a/project-fixtures/dev/mantle.yml
+++ b/project-fixtures/dev/mantle.yml
@@ -16,7 +16,6 @@ deployments:
       places:
         start:
           name: Preview - Start name
-  - name: existing
 
 templates:
   experience:

--- a/project-fixtures/dev/mantle.yml
+++ b/project-fixtures/dev/mantle.yml
@@ -16,6 +16,7 @@ deployments:
       places:
         start:
           name: Preview - Start name
+  - name: existing
 
 templates:
   experience:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,7 +10,7 @@ fn get_app() -> App<'static, 'static> {
         .setting(AppSettings::ArgRequiredElseHelp)
         .subcommand(
             SubCommand::with_name("deploy")
-                .about("Deploys a Mantle deployment")
+                .about("Deploys a Mantle deployment.")
                 .arg(
                     Arg::with_name("PROJECT")
                         .index(1)
@@ -31,7 +31,7 @@ fn get_app() -> App<'static, 'static> {
         )
         .subcommand(
             SubCommand::with_name("destroy")
-                .about("Destroys a Mantle deployment")
+                .about("Destroys a Mantle deployment.")
                 .arg(
                     Arg::with_name("PROJECT")
                         .index(1)
@@ -48,7 +48,7 @@ fn get_app() -> App<'static, 'static> {
         )
         .subcommand(
             SubCommand::with_name("outputs")
-                .about("Prints a Mantle deployment's outputs to the console or a file in a machine-readable format")
+                .about("Prints a Mantle deployment's outputs to the console or a file in a machine-readable format.")
                 .arg(
                     Arg::with_name("PROJECT")
                         .index(1)
@@ -79,6 +79,30 @@ fn get_app() -> App<'static, 'static> {
                         .possible_values(&["json","yaml"])
                         .default_value("json"))
         )
+        .subcommand(
+            SubCommand::with_name("import")
+                .about("Imports an existing experience into a Mantle deployment.")
+                .arg(
+                    Arg::with_name("PROJECT")
+                        .index(1)
+                        .help("The Mantle project: either the path to a directory containing a 'mantle.yml' file or the path to a configuration file. Defaults to the current directory.")
+                        .takes_value(true)
+                )
+                .arg(
+                    Arg::with_name("deployment")
+                        .long("deployment")
+                        .short("d")
+                        .help("The deployment to print the outputs of. If not specified, attempts to match the current git branch to each deployment's branches field.")
+                        .value_name("DEPLOYMENT")
+                        .takes_value(true))
+                .arg(
+                    Arg::with_name("experience_id")
+                        .long("experience-id")
+                        .help("The ID of the experience to import.")
+                        .value_name("ID")
+                        .takes_value(true)
+                        .required(true))
+        )
 }
 
 pub async fn run_with(args: Vec<String>) -> i32 {
@@ -106,6 +130,14 @@ pub async fn run_with(args: Vec<String>) -> i32 {
                 outputs_matches.value_of("deployment"),
                 outputs_matches.value_of("output"),
                 outputs_matches.value_of("format").unwrap(),
+            )
+            .await
+        }
+        ("import", Some(import_matches)) => {
+            commands::import::run(
+                import_matches.value_of("PROJECT"),
+                import_matches.value_of("deployment"),
+                import_matches.value_of("experience_id").unwrap(),
             )
             .await
         }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -4,7 +4,7 @@ use serde::de;
 use yansi::Paint;
 
 use crate::{
-    config::DeploymentConfig,
+    config::TemplateConfig,
     logger,
     project::{load_project, Project},
     resource_manager::{resource_types, RobloxResourceManager},
@@ -29,12 +29,12 @@ where
 }
 
 fn tag_commit(
-    deployment_config: &DeploymentConfig,
+    templates_config: &TemplateConfig,
     next_graph: &ResourceGraph,
     previous_graph: &ResourceGraph,
 ) -> Result<u32, String> {
     let mut tag_count: u32 = 0;
-    for name in deployment_config.place_ids.keys() {
+    for name in templates_config.places.as_ref().unwrap().keys() {
         let input_ref = (
             resource_types::PLACE_FILE.to_owned(),
             name.to_owned(),
@@ -81,7 +81,7 @@ pub async fn run(project: Option<&str>, deployment: Option<&str>, allow_purchase
         mut state,
         deployment_config,
         state_config,
-        ..
+        templates_config,
     } = match load_project(project, deployment).await {
         Ok(Some(v)) => v,
         Ok(None) => {
@@ -128,7 +128,7 @@ pub async fn run(project: Option<&str>, deployment: Option<&str>, allow_purchase
 
     if deployment_config.tag_commit && matches!(results, Ok(_)) {
         logger::start_action("Tagging commit:");
-        match tag_commit(&deployment_config, &next_graph, &previous_graph) {
+        match tag_commit(&templates_config, &next_graph, &previous_graph) {
             Ok(0) => logger::end_action("No tagging required"),
             Ok(tag_count) => {
                 logger::end_action(format!("Succeeded in pushing {} tag(s)", tag_count))

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1,0 +1,55 @@
+use yansi::Paint;
+
+use crate::{
+    logger,
+    project::{load_project, Project},
+    resource_manager::AssetId,
+    roblox_api::RobloxApi,
+    roblox_auth::RobloxAuth,
+    state::import_graph,
+};
+
+pub async fn run(project: Option<&str>, deployment: Option<&str>, experience_id: &str) -> i32 {
+    logger::start_action("Loading project:");
+    let Project {
+        mut state,
+        state_config,
+        ..
+    } = match load_project(project, deployment).await {
+        Ok(Some(v)) => v,
+        Ok(None) => {
+            logger::end_action("No deployment necessary");
+            return 0;
+        }
+        Err(e) => {
+            logger::end_action(Paint::red(e));
+            return 1;
+        }
+    };
+    logger::end_action("Succeeded");
+
+    let experience_id = match experience_id.parse::<AssetId>() {
+        Ok(v) => v,
+        Err(e) => {
+            logger::log(Paint::red(format!(
+                "Experience ID {} is invalid: {}",
+                experience_id, e
+            )));
+            return 1;
+        }
+    };
+
+    logger::start_action("Import experience:");
+    let mut roblox_api = RobloxApi::new(RobloxAuth::new());
+    let imported_graph = match import_graph(&mut roblox_api, experience_id) {
+        Ok(v) => v,
+        Err(e) => {
+            logger::end_action(Paint::red(format!("Failed: {}", e)));
+            return 1;
+        }
+    };
+    logger::log(format!("{:?}", imported_graph.get_resource_list()));
+    logger::end_action("Succeeded");
+
+    0
+}

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -48,7 +48,10 @@ pub async fn run(project: Option<&str>, deployment: Option<&str>, experience_id:
             return 1;
         }
     };
-    logger::log(format!("{:?}", imported_graph.get_resource_list()));
+    logger::log(format!(
+        "{}",
+        serde_yaml::to_string(&imported_graph.get_resource_list()).unwrap()
+    ));
     logger::end_action("Succeeded");
 
     0

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -30,7 +30,7 @@ pub async fn run(project: Option<&str>, deployment: Option<&str>, experience_id:
         }
     };
 
-    if previous_graph.get_resource_list().len() > 0 {
+    if !previous_graph.get_resource_list().is_empty() {
         logger::end_action("Deployment already exists: no need to import.");
         return 0;
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod deploy;
 pub mod destroy;
+pub mod import;
 pub mod outputs;

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,13 +61,6 @@ pub struct DeploymentConfig {
     #[serde(default)]
     pub tag_commit: bool,
 
-    // TODO: remove
-    pub experience_id: Option<u64>,
-
-    // TODO: remove
-    #[serde(default = "HashMap::new")]
-    pub place_ids: HashMap<String, u64>,
-
     pub overrides: Option<TemplateConfig>,
 }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -171,7 +171,7 @@ pub async fn load_project(
     let previous_graph =
         ResourceGraph::new(state.deployments.get(&deployment_config.name).unwrap());
     let next_graph =
-        get_desired_graph(project_path.as_path(), &templates_config, deployment_config)?;
+        get_desired_graph(project_path.as_path(), &templates_config)?;
 
     Ok(Some(Project {
         project_path,

--- a/src/project.rs
+++ b/src/project.rs
@@ -170,8 +170,7 @@ pub async fn load_project(
     // Get our resource graphs
     let previous_graph =
         ResourceGraph::new(state.deployments.get(&deployment_config.name).unwrap());
-    let next_graph =
-        get_desired_graph(project_path.as_path(), &templates_config)?;
+    let next_graph = get_desired_graph(project_path.as_path(), &templates_config)?;
 
     Ok(Some(Project {
         project_path,

--- a/src/resource_manager.rs
+++ b/src/resource_manager.rs
@@ -139,8 +139,8 @@ struct PlaceInputs {
 }
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-struct PlaceOutputs {
-    asset_id: AssetId,
+pub struct PlaceOutputs {
+    pub asset_id: AssetId,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -152,15 +152,15 @@ struct PlaceFileInputs {
 }
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-struct PlaceFileOutputs {
-    version: u32,
+pub struct PlaceFileOutputs {
+    pub version: u32,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-struct PlaceConfigurationInputs {
-    asset_id: AssetId,
-    configuration: PlaceConfigurationModel,
+pub struct PlaceConfigurationInputs {
+    pub asset_id: AssetId,
+    pub configuration: PlaceConfigurationModel,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -483,6 +483,7 @@ impl ResourceManager for RobloxResourceManager {
                 )?;
                 let GetPlaceResponse {
                     current_saved_version,
+                    ..
                 } = self.roblox_api.get_place(inputs.asset_id)?;
 
                 Ok(Some(

--- a/src/resource_manager.rs
+++ b/src/resource_manager.rs
@@ -47,9 +47,9 @@ struct ExperienceInputs {
 }
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-struct ExperienceOutputs {
-    asset_id: AssetId,
-    start_place_id: AssetId,
+pub struct ExperienceOutputs {
+    pub asset_id: AssetId,
+    pub start_place_id: AssetId,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -329,7 +329,7 @@ impl ResourceManager for RobloxResourceManager {
 
                 let outputs = match inputs.asset_id {
                     Some(asset_id) => {
-                        let GetExperienceResponse { root_place_id } =
+                        let GetExperienceResponse { root_place_id, .. } =
                             self.roblox_api.get_experience(asset_id)?;
                         ExperienceOutputs {
                             asset_id,

--- a/src/resource_manager.rs
+++ b/src/resource_manager.rs
@@ -75,8 +75,8 @@ struct ExperienceThumbnailInputs {
 }
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-struct ExperienceThumbnailOutputs {
-    asset_id: AssetId,
+pub struct ExperienceThumbnailOutputs {
+    pub asset_id: AssetId,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -89,8 +89,8 @@ struct ExperienceIconInputs {
 }
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-struct ExperienceIconOutputs {
-    asset_id: AssetId,
+pub struct ExperienceIconOutputs {
+    pub asset_id: AssetId,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -102,8 +102,8 @@ struct ExperienceDeveloperProductIconInputs {
 }
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-struct ExperienceDeveloperProductIconOutputs {
-    asset_id: AssetId,
+pub struct ExperienceDeveloperProductIconOutputs {
+    pub asset_id: AssetId,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -124,10 +124,9 @@ struct ExperienceDeveloperProductInputs {
 }
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-struct ExperienceDeveloperProductOutputs {
-    asset_id: AssetId,
-    product_id: AssetId,
-    shop_id: AssetId,
+pub struct ExperienceDeveloperProductOutputs {
+    pub asset_id: AssetId,
+    pub product_id: AssetId,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -175,9 +174,9 @@ struct GamePassInputs {
 }
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-struct GamePassOutputs {
-    asset_id: AssetId,
-    initial_icon_asset_id: AssetId,
+pub struct GamePassOutputs {
+    pub asset_id: AssetId,
+    pub initial_icon_asset_id: AssetId,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -190,8 +189,8 @@ struct GamePassIconInputs {
 }
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-struct GamePassIconOutputs {
-    asset_id: AssetId,
+pub struct GamePassIconOutputs {
+    pub asset_id: AssetId,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -205,9 +204,9 @@ struct BadgeInputs {
 }
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-struct BadgeOutputs {
-    asset_id: AssetId,
-    initial_icon_asset_id: AssetId,
+pub struct BadgeOutputs {
+    pub asset_id: AssetId,
+    pub initial_icon_asset_id: AssetId,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -220,8 +219,8 @@ struct BadgeIconInputs {
 }
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-struct BadgeIconOutputs {
-    asset_id: AssetId,
+pub struct BadgeIconOutputs {
+    pub asset_id: AssetId,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -233,8 +232,8 @@ struct AssetAliasInputs {
 }
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-struct AssetAliasOutputs {
-    name: String,
+pub struct AssetAliasOutputs {
+    pub name: String,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -245,9 +244,9 @@ struct ImageAssetInputs {
 }
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-struct ImageAssetOutputs {
-    asset_id: AssetId,
-    decal_asset_id: AssetId,
+pub struct ImageAssetOutputs {
+    pub asset_id: AssetId,
+    pub decal_asset_id: Option<AssetId>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -258,8 +257,8 @@ struct AudioAssetInputs {
 }
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-struct AudioAssetOutputs {
-    asset_id: AssetId,
+pub struct AudioAssetOutputs {
+    pub asset_id: AssetId,
 }
 
 pub struct RobloxResourceManager {
@@ -433,7 +432,7 @@ impl ResourceManager for RobloxResourceManager {
                     serde_yaml::from_value::<ExperienceDeveloperProductInputs>(resource_inputs)
                         .map_err(|e| format!("Failed to deserialize inputs: {}", e))?;
 
-                let CreateDeveloperProductResponse { id, shop_id } =
+                let CreateDeveloperProductResponse { id } =
                     self.roblox_api.create_developer_product(
                         inputs.experience_id,
                         inputs.name,
@@ -442,10 +441,7 @@ impl ResourceManager for RobloxResourceManager {
                         inputs.icon_asset_id,
                     )?;
 
-                let GetDeveloperProductResponse {
-                    product_id,
-                    developer_product_id: _,
-                } = self
+                let GetDeveloperProductResponse { product_id, .. } = self
                     .roblox_api
                     .find_developer_product_by_id(inputs.experience_id, id)?;
 
@@ -453,7 +449,6 @@ impl ResourceManager for RobloxResourceManager {
                     serde_yaml::to_value(ExperienceDeveloperProductOutputs {
                         asset_id: product_id,
                         product_id: id,
-                        shop_id,
                     })
                     .map_err(|e| format!("Failed to serialize outputs: {}", e))?,
                 ))
@@ -605,7 +600,7 @@ impl ResourceManager for RobloxResourceManager {
                 Ok(Some(
                     serde_yaml::to_value(ImageAssetOutputs {
                         asset_id: backing_asset_id,
-                        decal_asset_id: asset_id,
+                        decal_asset_id: Some(asset_id),
                     })
                     .map_err(|e| format!("Failed to serialize outputs: {}", e))?,
                 ))
@@ -926,7 +921,9 @@ impl ResourceManager for RobloxResourceManager {
                 let outputs = serde_yaml::from_value::<ImageAssetOutputs>(resource_outputs)
                     .map_err(|e| format!("Failed to deserialize outputs: {}", e))?;
 
-                self.roblox_api.archive_asset(outputs.decal_asset_id)?;
+                if let Some(decal_asset_id) = outputs.decal_asset_id {
+                    self.roblox_api.archive_asset(decal_asset_id)?;
+                }
 
                 Ok(())
             }

--- a/src/roblox_api.rs
+++ b/src/roblox_api.rs
@@ -37,6 +37,7 @@ pub struct CreateExperienceResponse {
 #[serde(rename_all = "camelCase")]
 pub struct GetExperienceResponse {
     pub root_place_id: AssetId,
+    pub is_active: bool,
 }
 
 #[derive(Deserialize)]
@@ -141,7 +142,7 @@ pub enum ExperienceGenre {
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "PascalCase")]
 pub enum ExperiencePlayableDevice {
     Computer,
     Phone,
@@ -157,14 +158,14 @@ pub enum ExperienceAvatarType {
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "PascalCase")]
 pub enum ExperienceAnimationType {
     Standard,
     PlayerChoice,
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "PascalCase")]
 pub enum ExperienceCollisionType {
     OuterBox,
     InnerBox,
@@ -397,6 +398,30 @@ impl RobloxApi {
         let model = response
             .into_json::<GetExperienceResponse>()
             .map_err(|e| format!("Failed to deserialize get experience response: {}", e))?;
+
+        Ok(model)
+    }
+
+    pub fn get_experience_configuration(
+        &mut self,
+        experience_id: AssetId,
+    ) -> Result<ExperienceConfigurationModel, String> {
+        let res = ureq::get(&format!(
+            "https://develop.roblox.com/v1/universes/{}/configuration",
+            experience_id
+        ))
+        .set_auth(AuthType::CookieAndCsrfToken, &mut self.roblox_auth)?
+        .call();
+
+        let response = Self::handle_response(res)?;
+        let model = response
+            .into_json::<ExperienceConfigurationModel>()
+            .map_err(|e| {
+                format!(
+                    "Failed to deserialize get experience configuration response: {}",
+                    e
+                )
+            })?;
 
         Ok(model)
     }


### PR DESCRIPTION
This PR removes the old `deployments.*.experienceId` and `deployments.*.placeIds` fields and adds a new `mantle import` command which can be used to generate a state file from an existing experience.

I think this is exactly how this flow should be implemented, but I do have concerns that some users will get confused by the term "import" and expect that they can just run `mantle import && mantle deploy` without properly configuring their project first. I will have to add a warning callout and write a guide on this process to avoid confusion.

Closes #52 