### PR TITLE
renamed deployments to environments, added versioning to state files

### DIFF
--- a/project-fixtures/dev/mantle.yml
+++ b/project-fixtures/dev/mantle.yml
@@ -1,4 +1,4 @@
-deployments:
+environments:
   - name: staging
     branches: [dev, dev/*]
     overrides:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,11 +6,11 @@ use std::env;
 fn get_app() -> App<'static, 'static> {
     App::new("Mantle")
         .version(crate_version!())
-        .about("Manages Roblox deployments")
+        .about("Infra-as-code and deployment tool for Roblox")
         .setting(AppSettings::ArgRequiredElseHelp)
         .subcommand(
             SubCommand::with_name("deploy")
-                .about("Deploys a Mantle deployment.")
+                .about("Updates a Mantle environment with a project's latest configuration.")
                 .arg(
                     Arg::with_name("PROJECT")
                         .index(1)
@@ -18,11 +18,11 @@ fn get_app() -> App<'static, 'static> {
                         .takes_value(true)
                 )
                 .arg(
-                    Arg::with_name("deployment")
-                        .long("deployment")
-                        .short("d")
-                        .help("The deployment to deploy. If not specified, attempts to match the current git branch to each deployment's branches field.")
-                        .value_name("DEPLOYMENT")
+                    Arg::with_name("environment")
+                        .long("environment")
+                        .short("e")
+                        .help("The environment to deploy to. If not specified, attempts to match the current git branch to each environment's `branches` field.")
+                        .value_name("ENVIRONMENT")
                         .takes_value(true))
                 .arg(
                     Arg::with_name("allow_purchases")
@@ -31,7 +31,7 @@ fn get_app() -> App<'static, 'static> {
         )
         .subcommand(
             SubCommand::with_name("destroy")
-                .about("Destroys a Mantle deployment.")
+                .about("Destroys a Mantle environment.")
                 .arg(
                     Arg::with_name("PROJECT")
                         .index(1)
@@ -39,16 +39,16 @@ fn get_app() -> App<'static, 'static> {
                         .takes_value(true)
                 )
                 .arg(
-                    Arg::with_name("deployment")
-                        .long("deployment")
-                        .short("d")
-                        .help("The deployment to destroy. If not specified, attempts to match the current git branch to each deployment's branches field.")
-                        .value_name("DEPLOYMENT")
+                    Arg::with_name("environment")
+                        .long("environment")
+                        .short("e")
+                        .help("The environment to destroy. If not specified, attempts to match the current git branch to each environment's `branches` field.")
+                        .value_name("ENVIRONMENT")
                         .takes_value(true))
         )
         .subcommand(
             SubCommand::with_name("outputs")
-                .about("Prints a Mantle deployment's outputs to the console or a file in a machine-readable format.")
+                .about("Prints a Mantle environment's outputs to the console or a file in a machine-readable format.")
                 .arg(
                     Arg::with_name("PROJECT")
                         .index(1)
@@ -56,11 +56,11 @@ fn get_app() -> App<'static, 'static> {
                         .takes_value(true)
                 )
                 .arg(
-                    Arg::with_name("deployment")
-                        .long("deployment")
-                        .short("d")
-                        .help("The deployment to print the outputs of. If not specified, attempts to match the current git branch to each deployment's branches field.")
-                        .value_name("DEPLOYMENT")
+                    Arg::with_name("environment")
+                        .long("environment")
+                        .short("e")
+                        .help("The environment to print the outputs of. If not specified, attempts to match the current git branch to each environment's `branches` field.")
+                        .value_name("ENVIRONMENT")
                         .takes_value(true))
                 .arg(
                     Arg::with_name("output")
@@ -81,7 +81,7 @@ fn get_app() -> App<'static, 'static> {
         )
         .subcommand(
             SubCommand::with_name("import")
-                .about("Imports an existing experience into a Mantle deployment.")
+                .about("Imports an existing target into a Mantle environment.")
                 .arg(
                     Arg::with_name("PROJECT")
                         .index(1)
@@ -89,11 +89,11 @@ fn get_app() -> App<'static, 'static> {
                         .takes_value(true)
                 )
                 .arg(
-                    Arg::with_name("deployment")
-                        .long("deployment")
-                        .short("d")
-                        .help("The deployment to print the outputs of. If not specified, attempts to match the current git branch to each deployment's branches field.")
-                        .value_name("DEPLOYMENT")
+                    Arg::with_name("environment")
+                        .long("environment")
+                        .short("e")
+                        .help("The environment to print the outputs of. If not specified, attempts to match the current git branch to each environment's `branches` field.")
+                        .value_name("ENVIRONMENT")
                         .takes_value(true))
                 .arg(
                     Arg::with_name("experience_id")
@@ -112,7 +112,7 @@ pub async fn run_with(args: Vec<String>) -> i32 {
         ("deploy", Some(deploy_matches)) => {
             commands::deploy::run(
                 deploy_matches.value_of("PROJECT"),
-                deploy_matches.value_of("deployment"),
+                deploy_matches.value_of("environment"),
                 deploy_matches.is_present("allow_purchases"),
             )
             .await
@@ -120,14 +120,14 @@ pub async fn run_with(args: Vec<String>) -> i32 {
         ("destroy", Some(destroy_matches)) => {
             commands::destroy::run(
                 destroy_matches.value_of("PROJECT"),
-                destroy_matches.value_of("deployment"),
+                destroy_matches.value_of("environment"),
             )
             .await
         }
         ("outputs", Some(outputs_matches)) => {
             commands::outputs::run(
                 outputs_matches.value_of("PROJECT"),
-                outputs_matches.value_of("deployment"),
+                outputs_matches.value_of("environment"),
                 outputs_matches.value_of("output"),
                 outputs_matches.value_of("format").unwrap(),
             )
@@ -136,7 +136,7 @@ pub async fn run_with(args: Vec<String>) -> i32 {
         ("import", Some(import_matches)) => {
             commands::import::run(
                 import_matches.value_of("PROJECT"),
-                import_matches.value_of("deployment"),
+                import_matches.value_of("environment"),
                 import_matches.value_of("experience_id").unwrap(),
             )
             .await

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -72,17 +72,17 @@ fn tag_commit(
     Ok(tag_count)
 }
 
-pub async fn run(project: Option<&str>, deployment: Option<&str>, allow_purchases: bool) -> i32 {
+pub async fn run(project: Option<&str>, environment: Option<&str>, allow_purchases: bool) -> i32 {
     logger::start_action("Loading project:");
     let Project {
         project_path,
         mut next_graph,
         previous_graph,
         mut state,
-        deployment_config,
+        environment_config,
         state_config,
         templates_config,
-    } = match load_project(project, deployment).await {
+    } = match load_project(project, environment).await {
         Ok(Some(v)) => v,
         Ok(None) => {
             logger::end_action("No deployment necessary");
@@ -126,7 +126,7 @@ pub async fn run(project: Option<&str>, deployment: Option<&str>, allow_purchase
         }
     };
 
-    if deployment_config.tag_commit && matches!(results, Ok(_)) {
+    if environment_config.tag_commit && matches!(results, Ok(_)) {
         logger::start_action("Tagging commit:");
         match tag_commit(&templates_config, &next_graph, &previous_graph) {
             Ok(0) => logger::end_action("No tagging required"),
@@ -138,8 +138,8 @@ pub async fn run(project: Option<&str>, deployment: Option<&str>, allow_purchase
     }
 
     logger::start_action("Saving state:");
-    state.deployments.insert(
-        deployment_config.name.clone(),
+    state.environments.insert(
+        environment_config.name.clone(),
         next_graph.get_resource_list(),
     );
     match save_state(&project_path, &state_config, &state).await {

--- a/src/commands/destroy.rs
+++ b/src/commands/destroy.rs
@@ -10,16 +10,16 @@ use crate::{
     state::save_state,
 };
 
-pub async fn run(project: Option<&str>, deployment: Option<&str>) -> i32 {
+pub async fn run(project: Option<&str>, environment: Option<&str>) -> i32 {
     logger::start_action("Loading project:");
     let Project {
         project_path,
         previous_graph,
         mut state,
-        deployment_config,
+        environment_config,
         state_config,
         ..
-    } = match load_project(project, deployment).await {
+    } = match load_project(project, environment).await {
         Ok(Some(v)) => v,
         Ok(None) => {
             logger::end_action("No deployment necessary");
@@ -54,7 +54,7 @@ pub async fn run(project: Option<&str>, deployment: Option<&str>) -> i32 {
     };
 
     logger::start_action("Saving state:");
-    state.deployments.remove(&deployment_config.name);
+    state.environments.remove(&environment_config.name);
     match save_state(&project_path, &state_config, &state).await {
         Ok(_) => {}
         Err(e) => {

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -9,19 +9,19 @@ use crate::{
     state::{import_graph, save_state},
 };
 
-pub async fn run(project: Option<&str>, deployment: Option<&str>, experience_id: &str) -> i32 {
+pub async fn run(project: Option<&str>, environment: Option<&str>, experience_id: &str) -> i32 {
     logger::start_action("Loading project:");
     let Project {
         project_path,
         previous_graph,
         mut state,
-        deployment_config,
+        environment_config,
         state_config,
         ..
-    } = match load_project(project, deployment).await {
+    } = match load_project(project, environment).await {
         Ok(Some(v)) => v,
         Ok(None) => {
-            logger::end_action("No deployment necessary");
+            logger::end_action("No import necessary");
             return 0;
         }
         Err(e) => {
@@ -31,7 +31,7 @@ pub async fn run(project: Option<&str>, deployment: Option<&str>, experience_id:
     };
 
     if !previous_graph.get_resource_list().is_empty() {
-        logger::end_action("Deployment already exists: no need to import.");
+        logger::end_action("Environment state already exists: no need to import.");
         return 0;
     }
 
@@ -60,8 +60,8 @@ pub async fn run(project: Option<&str>, deployment: Option<&str>, experience_id:
     logger::end_action("Succeeded");
 
     logger::start_action("Saving state:");
-    state.deployments.insert(
-        deployment_config.name.clone(),
+    state.environments.insert(
+        environment_config.name.clone(),
         imported_graph.get_resource_list(),
     );
     match save_state(&project_path, &state_config, &state).await {

--- a/src/commands/outputs.rs
+++ b/src/commands/outputs.rs
@@ -10,12 +10,12 @@ use crate::{
 
 pub async fn run(
     project: Option<&str>,
-    deployment: Option<&str>,
+    environment: Option<&str>,
     output: Option<&str>,
     format: &str,
 ) -> i32 {
     logger::start_action("Load outputs:");
-    let Project { previous_graph, .. } = match load_project(project, deployment).await {
+    let Project { previous_graph, .. } = match load_project(project, environment).await {
         Ok(Some(v)) => v,
         Ok(None) => {
             logger::end_action("No outputs available");

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ use std::{collections::HashMap, default, fmt, fs, path::Path, str};
 #[serde(rename_all = "camelCase")]
 pub struct Config {
     #[serde(default = "Vec::new")]
-    pub deployments: Vec<DeploymentConfig>,
+    pub environments: Vec<EnvironmentConfig>,
 
     pub templates: TemplateConfig,
 
@@ -52,7 +52,7 @@ impl fmt::Display for RemoteStateConfig {
 
 #[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct DeploymentConfig {
+pub struct EnvironmentConfig {
     pub name: String,
 
     #[serde(default = "Vec::new")]


### PR DESCRIPTION
Closes #64 

This PR renames "deployments" to "environments". In doing so, it changes the state file API which would break existing projects. To fix this, this PR also adds a simple versioning and auto-migration system for state files. I also discovered another breaking change introduced in #73 which caused old state files consumed by the latest version to re-create all experience and place resources. Since that change is not released yet, I included a fix for it in the state file version migration.