### PR TITLE
replace templates configuration with target and refactor to support future target types

### DIFF
--- a/project-fixtures/dev/mantle.yml
+++ b/project-fixtures/dev/mantle.yml
@@ -6,12 +6,12 @@ environments:
         start:
           configuration:
             name: Staging - Start name
-      places.start.configuration.name: Staging - Start name
+      # places.start.configuration.name: Staging - Start name
   - name: production
     branches: [main]
     # tagCommit: true
     overrides:
-      experience:
+      configuration:
         playability: friends
   - name: preview
     overrides:

--- a/project-fixtures/dev/mantle.yml
+++ b/project-fixtures/dev/mantle.yml
@@ -6,7 +6,6 @@ environments:
         start:
           configuration:
             name: Staging - Start name
-      # places.start.configuration.name: Staging - Start name
   - name: production
     branches: [main]
     # tagCommit: true

--- a/project-fixtures/dev/mantle.yml
+++ b/project-fixtures/dev/mantle.yml
@@ -4,7 +4,9 @@ environments:
     overrides:
       places:
         start:
-          name: Staging - Start name
+          configuration:
+            name: Staging - Start name
+      places.start.configuration.name: Staging - Start name
   - name: production
     branches: [main]
     # tagCommit: true
@@ -15,55 +17,60 @@ environments:
     overrides:
       places:
         start:
-          name: Preview - Start name
+          configuration:
+            name: Preview - Start name
 
-templates:
+target:
   experience:
-    genre: naval
-    playableDevices: [computer]
-    playability: private
-    enableStudioAccessToApis: true
-    avatarType: r15
-    avatarAnimationType: playerChoice
-    avatarCollisionType: outerBox
-    icon: game-icon.png
-    thumbnails:
-      - game-thumbnail-1.png
-      - game-thumbnail-2.png
-      - game-thumbnail-3.png
-  places:
-    start:
-      file: start.rbxlx
-      name: Start name
-      description: Start description
-      maxPlayerCount: 20
-      serverFill: { reservedSlots: 10 }
-      allowCopying: false
-    firstWorld:
-      file: start.rbxlx
-      name: World
-    secondWorld:
-      file: start.rbxlx
-      name: Second World
-  products:
-    myFirstProduct:
-      name: My first product
-      description: With an amazing description
-      price: 50
-      icon: developer-product-1.png
-  passes:
-    myFirstPass:
-      name: My first pass
-      description: With a description!
-      price: 50
-      icon: game-pass-1.png
-  badges:
-    myFirstBadge:
-      name: My first badge
-      description: The best badge of all
-      icon: badge-1.png
-  assets:
-    - assets/*
+    configuration:
+      genre: naval
+      playableDevices: [computer]
+      playability: private
+      enableStudioAccessToApis: true
+      avatarType: r15
+      avatarAnimationType: playerChoice
+      avatarCollisionType: outerBox
+      icon: game-icon.png
+      thumbnails:
+        - game-thumbnail-1.png
+        - game-thumbnail-2.png
+        - game-thumbnail-3.png
+    places:
+      start:
+        file: start.rbxlx
+        configuration:
+          name: Start name
+          description: Start description
+          maxPlayerCount: 20
+          serverFill: { reservedSlots: 10 }
+          allowCopying: false
+      firstWorld:
+        file: start.rbxlx
+        configuration:
+          name: World
+      secondWorld:
+        file: start.rbxlx
+        configuration:
+          name: Second World
+    products:
+      myFirstProduct:
+        name: My first product
+        description: With an amazing description
+        price: 50
+        icon: developer-product-1.png
+    passes:
+      myFirstPass:
+        name: My first pass
+        description: With a description!
+        price: 50
+        icon: game-pass-1.png
+    badges:
+      myFirstBadge:
+        name: My first badge
+        description: The best badge of all
+        icon: badge-1.png
+    assets:
+      - assets/*
 
 state:
   remote:

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,14 +1,14 @@
-use std::{collections::BTreeMap, str};
+use std::str;
 
 use serde::de;
 use yansi::Paint;
 
 use crate::{
-    config::{ExperienceTargetConfig, TargetConfig},
+    config::TargetConfig,
     logger,
     project::{load_project, Project},
     resource_manager::{resource_types, RobloxResourceManager},
-    resources::{EvaluateResults, InputRef, Resource, ResourceGraph, ResourceRef},
+    resources::{EvaluateResults, InputRef, ResourceGraph},
     state::save_state,
     util::run_command,
 };

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,14 +1,14 @@
-use std::str;
+use std::{collections::BTreeMap, str};
 
 use serde::de;
 use yansi::Paint;
 
 use crate::{
-    config::TemplateConfig,
+    config::{ExperienceTargetConfig, TargetConfig},
     logger,
     project::{load_project, Project},
     resource_manager::{resource_types, RobloxResourceManager},
-    resources::{EvaluateResults, InputRef, ResourceGraph},
+    resources::{EvaluateResults, InputRef, Resource, ResourceGraph, ResourceRef},
     state::save_state,
     util::run_command,
 };
@@ -29,38 +29,42 @@ where
 }
 
 fn tag_commit(
-    templates_config: &TemplateConfig,
+    target_config: &TargetConfig,
     next_graph: &ResourceGraph,
     previous_graph: &ResourceGraph,
 ) -> Result<u32, String> {
     let mut tag_count: u32 = 0;
-    for name in templates_config.places.as_ref().unwrap().keys() {
-        let input_ref = (
-            resource_types::PLACE_FILE.to_owned(),
-            name.to_owned(),
-            "version".to_owned(),
-        );
-        let previous_version_output = get_output::<u32>(previous_graph, &input_ref);
-        let next_version_output = get_output::<u32>(next_graph, &input_ref);
 
-        let tag_version = match (previous_version_output, next_version_output) {
-            (None, Some(version)) => Some(version),
-            (Some(previous), Some(next)) if next != previous => Some(next),
-            _ => None,
-        };
+    #[allow(irrefutable_let_patterns)]
+    if let TargetConfig::Experience(target_config) = target_config {
+        for name in target_config.places.as_ref().unwrap().keys() {
+            let input_ref = (
+                resource_types::PLACE_FILE.to_owned(),
+                name.to_owned(),
+                "version".to_owned(),
+            );
+            let previous_version_output = get_output::<u32>(previous_graph, &input_ref);
+            let next_version_output = get_output::<u32>(next_graph, &input_ref);
 
-        if let Some(version) = tag_version {
-            logger::log(format!(
-                "Place {} was updated to version {}",
-                Paint::cyan(name),
-                Paint::cyan(version)
-            ));
-            let tag = format!("{}-v{}", name, version);
-            logger::log(format!("Tagging commit with {}", Paint::cyan(tag.clone())));
+            let tag_version = match (previous_version_output, next_version_output) {
+                (None, Some(version)) => Some(version),
+                (Some(previous), Some(next)) if next != previous => Some(next),
+                _ => None,
+            };
 
-            tag_count += 1;
-            run_command(&format!("git tag {}", tag))
-                .map_err(|e| format!("Unable to tag the current commit\n\t{}", e))?;
+            if let Some(version) = tag_version {
+                logger::log(format!(
+                    "Place {} was updated to version {}",
+                    Paint::cyan(name),
+                    Paint::cyan(version)
+                ));
+                let tag = format!("{}-v{}", name, version);
+                logger::log(format!("Tagging commit with {}", Paint::cyan(tag.clone())));
+
+                tag_count += 1;
+                run_command(&format!("git tag {}", tag))
+                    .map_err(|e| format!("Unable to tag the current commit\n\t{}", e))?;
+            }
         }
     }
 
@@ -68,7 +72,6 @@ fn tag_commit(
         run_command("git push --tags")
             .map_err(|e| format!("Unable to push tags to remote\n\t{}", e))?;
     }
-
     Ok(tag_count)
 }
 
@@ -81,7 +84,7 @@ pub async fn run(project: Option<&str>, environment: Option<&str>, allow_purchas
         mut state,
         environment_config,
         state_config,
-        templates_config,
+        target_config,
     } = match load_project(project, environment).await {
         Ok(Some(v)) => v,
         Ok(None) => {
@@ -128,7 +131,7 @@ pub async fn run(project: Option<&str>, environment: Option<&str>, allow_purchas
 
     if environment_config.tag_commit && matches!(results, Ok(_)) {
         logger::start_action("Tagging commit:");
-        match tag_commit(&templates_config, &next_graph, &previous_graph) {
+        match tag_commit(&target_config, &next_graph, &previous_graph) {
             Ok(0) => logger::end_action("No tagging required"),
             Ok(tag_count) => {
                 logger::end_action(format!("Succeeded in pushing {} tag(s)", tag_count))

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,22 +73,22 @@ pub enum TargetConfig {
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ExperienceTargetConfig {
-    pub experience: Option<ExperienceTemplateConfig>,
+    pub configuration: Option<ExperienceTargetConfigurationConfig>,
 
-    pub places: Option<HashMap<String, PlaceTemplateConfig>>,
+    pub places: Option<HashMap<String, PlaceTargetConfig>>,
 
-    pub products: Option<HashMap<String, DeveloperProductConifg>>,
+    pub products: Option<HashMap<String, ProductTargetConifg>>,
 
-    pub passes: Option<HashMap<String, PassTemplateConfig>>,
+    pub passes: Option<HashMap<String, PassTargetConfig>>,
 
-    pub badges: Option<HashMap<String, BadgeConfig>>,
+    pub badges: Option<HashMap<String, BadgeTargetConfig>>,
 
-    pub assets: Option<Vec<AssetConfig>>,
+    pub assets: Option<Vec<AssetTargetConfig>>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub enum GenreConfig {
+pub enum GenreTargetConfig {
     All,
     Adventure,
     Building,
@@ -108,7 +108,7 @@ pub enum GenreConfig {
 
 #[derive(Serialize, Deserialize, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
-pub enum PlayabilityConfig {
+pub enum PlayabilityTargetConfig {
     Private,
     Public,
     Friends,
@@ -116,7 +116,7 @@ pub enum PlayabilityConfig {
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub enum AvatarTypeConfig {
+pub enum AvatarTypeTargetConfig {
     R6,
     R15,
     PlayerChoice,
@@ -124,7 +124,7 @@ pub enum AvatarTypeConfig {
 
 #[derive(Serialize, Deserialize, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
-pub enum PlayableDeviceConfig {
+pub enum PlayableDeviceTargetConfig {
     Computer,
     Phone,
     Tablet,
@@ -133,63 +133,63 @@ pub enum PlayableDeviceConfig {
 
 #[derive(Serialize, Deserialize, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
-pub enum AnimationTypeConfig {
+pub enum AnimationTypeTargetConfig {
     Standard,
     PlayerChoice,
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
-pub enum CollisionTypeConfig {
+pub enum CollisionTypeTargetConfig {
     OuterBox,
     InnerBox,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct DeveloperProductConifg {
-    pub name: Option<String>,
-    pub price: Option<u32>,
+pub struct ProductTargetConifg {
+    pub name: String,
     pub description: Option<String>,
     pub icon: Option<String>,
+    pub price: u32,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct PassTemplateConfig {
-    pub name: Option<String>,
+pub struct PassTargetConfig {
+    pub name: String,
     pub description: Option<String>,
-    pub icon: Option<String>,
+    pub icon: String,
     pub price: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct BadgeConfig {
-    pub name: Option<String>,
+pub struct BadgeTargetConfig {
+    pub name: String,
     pub description: Option<String>,
-    pub icon: Option<String>,
+    pub icon: String,
     pub enabled: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase", untagged)]
-pub enum AssetConfig {
+pub enum AssetTargetConfig {
     File(String),
     FileWithAlias { file: String, name: String },
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct ExperienceTemplateConfig {
+pub struct ExperienceTargetConfigurationConfig {
     // basic info
-    pub genre: Option<GenreConfig>,
-    pub playable_devices: Option<Vec<PlayableDeviceConfig>>,
+    pub genre: Option<GenreTargetConfig>,
+    pub playable_devices: Option<Vec<PlayableDeviceTargetConfig>>,
     pub icon: Option<String>,
     pub thumbnails: Option<Vec<String>>,
 
     // permissions
-    pub playability: Option<PlayabilityConfig>,
+    pub playability: Option<PlayabilityTargetConfig>,
 
     // monetization
     // badges: // TODO: create badges
@@ -205,49 +205,49 @@ pub struct ExperienceTemplateConfig {
     // localization: // TODO: localization
 
     // avatar
-    pub avatar_type: Option<AvatarTypeConfig>,
-    pub avatar_animation_type: Option<AnimationTypeConfig>,
-    pub avatar_collision_type: Option<CollisionTypeConfig>,
+    pub avatar_type: Option<AvatarTypeTargetConfig>,
+    pub avatar_animation_type: Option<AnimationTypeTargetConfig>,
+    pub avatar_collision_type: Option<CollisionTypeTargetConfig>,
     // avatar_asset_overrides: Option<HashMap<String, u64>>,    // TODO: figure out api
     // avatar_scale_constraints: Option<HashMap<String, (f32, f32)>>,   // TODO: figure out api
 }
 
-impl From<&ExperienceTemplateConfig> for ExperienceConfigurationModel {
-    fn from(config: &ExperienceTemplateConfig) -> Self {
+impl From<&ExperienceTargetConfigurationConfig> for ExperienceConfigurationModel {
+    fn from(config: &ExperienceTargetConfigurationConfig) -> Self {
         ExperienceConfigurationModel {
             genre: match config.genre {
-                Some(GenreConfig::All) => Some(ExperienceGenre::All),
-                Some(GenreConfig::Adventure) => Some(ExperienceGenre::Adventure),
-                Some(GenreConfig::Building) => Some(ExperienceGenre::Tutorial),
-                Some(GenreConfig::Comedy) => Some(ExperienceGenre::Funny),
-                Some(GenreConfig::Fighting) => Some(ExperienceGenre::Ninja),
-                Some(GenreConfig::Fps) => Some(ExperienceGenre::Fps),
-                Some(GenreConfig::Horror) => Some(ExperienceGenre::Scary),
-                Some(GenreConfig::Medieval) => Some(ExperienceGenre::Fantasy),
-                Some(GenreConfig::Military) => Some(ExperienceGenre::War),
-                Some(GenreConfig::Naval) => Some(ExperienceGenre::Pirate),
-                Some(GenreConfig::Rpg) => Some(ExperienceGenre::Rpg),
-                Some(GenreConfig::SciFi) => Some(ExperienceGenre::SciFi),
-                Some(GenreConfig::Sports) => Some(ExperienceGenre::Sports),
-                Some(GenreConfig::TownAndCity) => Some(ExperienceGenre::TownAndCity),
-                Some(GenreConfig::Western) => Some(ExperienceGenre::WildWest),
+                Some(GenreTargetConfig::All) => Some(ExperienceGenre::All),
+                Some(GenreTargetConfig::Adventure) => Some(ExperienceGenre::Adventure),
+                Some(GenreTargetConfig::Building) => Some(ExperienceGenre::Tutorial),
+                Some(GenreTargetConfig::Comedy) => Some(ExperienceGenre::Funny),
+                Some(GenreTargetConfig::Fighting) => Some(ExperienceGenre::Ninja),
+                Some(GenreTargetConfig::Fps) => Some(ExperienceGenre::Fps),
+                Some(GenreTargetConfig::Horror) => Some(ExperienceGenre::Scary),
+                Some(GenreTargetConfig::Medieval) => Some(ExperienceGenre::Fantasy),
+                Some(GenreTargetConfig::Military) => Some(ExperienceGenre::War),
+                Some(GenreTargetConfig::Naval) => Some(ExperienceGenre::Pirate),
+                Some(GenreTargetConfig::Rpg) => Some(ExperienceGenre::Rpg),
+                Some(GenreTargetConfig::SciFi) => Some(ExperienceGenre::SciFi),
+                Some(GenreTargetConfig::Sports) => Some(ExperienceGenre::Sports),
+                Some(GenreTargetConfig::TownAndCity) => Some(ExperienceGenre::TownAndCity),
+                Some(GenreTargetConfig::Western) => Some(ExperienceGenre::WildWest),
                 None => None,
             },
             playable_devices: config.playable_devices.as_ref().map(|devices| {
                 devices
                     .iter()
                     .map(|d| match d {
-                        PlayableDeviceConfig::Computer => ExperiencePlayableDevice::Computer,
-                        PlayableDeviceConfig::Console => ExperiencePlayableDevice::Console,
-                        PlayableDeviceConfig::Phone => ExperiencePlayableDevice::Phone,
-                        PlayableDeviceConfig::Tablet => ExperiencePlayableDevice::Tablet,
+                        PlayableDeviceTargetConfig::Computer => ExperiencePlayableDevice::Computer,
+                        PlayableDeviceTargetConfig::Console => ExperiencePlayableDevice::Console,
+                        PlayableDeviceTargetConfig::Phone => ExperiencePlayableDevice::Phone,
+                        PlayableDeviceTargetConfig::Tablet => ExperiencePlayableDevice::Tablet,
                     })
                     .collect()
             }),
 
             is_friends_only: match config.playability {
-                Some(PlayabilityConfig::Friends) => Some(true),
-                Some(PlayabilityConfig::Public) => Some(false),
+                Some(PlayabilityTargetConfig::Friends) => Some(true),
+                Some(PlayabilityTargetConfig::Public) => Some(false),
                 _ => None,
             },
 
@@ -277,21 +277,29 @@ impl From<&ExperienceTemplateConfig> for ExperienceConfigurationModel {
             },
 
             universe_avatar_type: match config.avatar_type {
-                Some(AvatarTypeConfig::R6) => Some(ExperienceAvatarType::MorphToR6),
-                Some(AvatarTypeConfig::R15) => Some(ExperienceAvatarType::MorphToR15),
-                Some(AvatarTypeConfig::PlayerChoice) => Some(ExperienceAvatarType::PlayerChoice),
+                Some(AvatarTypeTargetConfig::R6) => Some(ExperienceAvatarType::MorphToR6),
+                Some(AvatarTypeTargetConfig::R15) => Some(ExperienceAvatarType::MorphToR15),
+                Some(AvatarTypeTargetConfig::PlayerChoice) => {
+                    Some(ExperienceAvatarType::PlayerChoice)
+                }
                 None => None,
             },
             universe_animation_type: match config.avatar_animation_type {
-                Some(AnimationTypeConfig::Standard) => Some(ExperienceAnimationType::Standard),
-                Some(AnimationTypeConfig::PlayerChoice) => {
+                Some(AnimationTypeTargetConfig::Standard) => {
+                    Some(ExperienceAnimationType::Standard)
+                }
+                Some(AnimationTypeTargetConfig::PlayerChoice) => {
                     Some(ExperienceAnimationType::PlayerChoice)
                 }
                 None => None,
             },
             universe_collision_type: match config.avatar_collision_type {
-                Some(CollisionTypeConfig::InnerBox) => Some(ExperienceCollisionType::InnerBox),
-                Some(CollisionTypeConfig::OuterBox) => Some(ExperienceCollisionType::OuterBox),
+                Some(CollisionTypeTargetConfig::InnerBox) => {
+                    Some(ExperienceCollisionType::InnerBox)
+                }
+                Some(CollisionTypeTargetConfig::OuterBox) => {
+                    Some(ExperienceCollisionType::OuterBox)
+                }
                 None => None,
             },
 
@@ -302,7 +310,7 @@ impl From<&ExperienceTemplateConfig> for ExperienceConfigurationModel {
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub enum ServerFillConfig {
+pub enum ServerFillTargetConfig {
     RobloxOptimized,
     Maximum,
     ReservedSlots(u32),
@@ -310,30 +318,36 @@ pub enum ServerFillConfig {
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct PlaceTemplateConfig {
+pub struct PlaceTargetConfig {
     pub file: Option<String>,
+    pub configuration: Option<PlaceTargetConfigurationConfig>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PlaceTargetConfigurationConfig {
     pub name: Option<String>,
     pub description: Option<String>,
     pub max_player_count: Option<u32>,
     pub allow_copying: Option<bool>,
-    pub server_fill: Option<ServerFillConfig>,
+    pub server_fill: Option<ServerFillTargetConfig>,
 }
 
-impl From<PlaceTemplateConfig> for PlaceConfigurationModel {
-    fn from(config: PlaceTemplateConfig) -> Self {
+impl From<PlaceTargetConfigurationConfig> for PlaceConfigurationModel {
+    fn from(config: PlaceTargetConfigurationConfig) -> Self {
         PlaceConfigurationModel {
             name: config.name.clone(),
             description: config.description.clone(),
             max_player_count: config.max_player_count,
             allow_copying: config.allow_copying,
             social_slot_type: match config.server_fill {
-                Some(ServerFillConfig::RobloxOptimized) => Some(SocialSlotType::Automatic),
-                Some(ServerFillConfig::Maximum) => Some(SocialSlotType::Empty),
-                Some(ServerFillConfig::ReservedSlots(_)) => Some(SocialSlotType::Custom),
+                Some(ServerFillTargetConfig::RobloxOptimized) => Some(SocialSlotType::Automatic),
+                Some(ServerFillTargetConfig::Maximum) => Some(SocialSlotType::Empty),
+                Some(ServerFillTargetConfig::ReservedSlots(_)) => Some(SocialSlotType::Custom),
                 None => None,
             },
             custom_social_slot_count: match config.server_fill {
-                Some(ServerFillConfig::ReservedSlots(count)) => Some(count),
+                Some(ServerFillTargetConfig::ReservedSlots(count)) => Some(count),
                 _ => None,
             },
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@ pub struct Config {
     #[serde(default = "Vec::new")]
     pub environments: Vec<EnvironmentConfig>,
 
-    pub templates: TemplateConfig,
+    pub target: TargetConfig,
 
     #[serde(default)]
     pub state: StateConfig,
@@ -61,12 +61,18 @@ pub struct EnvironmentConfig {
     #[serde(default)]
     pub tag_commit: bool,
 
-    pub overrides: Option<TemplateConfig>,
+    pub overrides: Option<serde_yaml::Value>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct TemplateConfig {
+pub enum TargetConfig {
+    Experience(ExperienceTargetConfig),
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ExperienceTargetConfig {
     pub experience: Option<ExperienceTemplateConfig>,
 
     pub places: Option<HashMap<String, PlaceTemplateConfig>>,

--- a/src/state.rs
+++ b/src/state.rs
@@ -13,8 +13,8 @@ use yansi::Paint;
 
 use crate::{
     config::{
-        AssetConfig, Config, EnvironmentConfig, ExperienceTargetConfig, PlayabilityConfig,
-        RemoteStateConfig, StateConfig, TargetConfig,
+        AssetTargetConfig, Config, EnvironmentConfig, ExperienceTargetConfig,
+        PlayabilityTargetConfig, RemoteStateConfig, StateConfig, TargetConfig,
     },
     logger,
     resource_manager::{
@@ -218,7 +218,7 @@ fn get_desired_experience_graph(
     let experience_start_place_id_ref = experience.get_input_ref("startPlaceId");
     resources.push(experience);
 
-    if let Some(experience_configuration) = &target_config.experience {
+    if let Some(experience_configuration) = &target_config.configuration {
         resources.push(
             Resource::new(
                 resource_types::EXPERIENCE_CONFIGURATION,
@@ -238,7 +238,7 @@ fn get_desired_experience_graph(
                     "isActive",
                     &!matches!(
                         experience_configuration.playability,
-                        Some(PlayabilityConfig::Private)
+                        Some(PlayabilityTargetConfig::Private)
                     ),
                 )?
                 .add_ref_input("experienceId", &experience_asset_id_ref)
@@ -291,68 +291,56 @@ fn get_desired_experience_graph(
             return Err("No start place defined".to_owned());
         }
 
-        for (name, target) in places.iter() {
-            let place_file = target
-                .file
-                .clone()
-                .ok_or(format!("Missing required field file for place {}", name))?;
-
-            let place = Resource::new(resource_types::PLACE, name)
+        for (name, place) in places.iter() {
+            let place_resource = Resource::new(resource_types::PLACE, name)
                 .add_ref_input("experienceId", &experience_asset_id_ref)
                 .add_ref_input("startPlaceId", &experience_start_place_id_ref)
                 .add_value_input("isStart", &(name == "start"))?
                 .clone();
-            let place_asset_id_ref = place.get_input_ref("assetId");
-            resources.push(place);
+            let place_asset_id_ref = place_resource.get_input_ref("assetId");
+            resources.push(place_resource);
 
-            resources.push(
-                Resource::new(resource_types::PLACE_FILE, name)
-                    .add_ref_input("assetId", &place_asset_id_ref)
-                    .add_value_input("filePath", &place_file)?
-                    .add_value_input(
-                        "fileHash",
-                        &get_file_hash(project_path.join(&place_file).as_path())?,
-                    )?
-                    .clone(),
-            );
+            if let Some(file) = &place.file {
+                resources.push(
+                    Resource::new(resource_types::PLACE_FILE, name)
+                        .add_ref_input("assetId", &place_asset_id_ref)
+                        .add_value_input("filePath", file)?
+                        .add_value_input(
+                            "fileHash",
+                            &get_file_hash(project_path.join(file).as_path())?,
+                        )?
+                        .clone(),
+                );
+            }
 
-            resources.push(
-                Resource::new(resource_types::PLACE_CONFIGURATION, name)
-                    .add_ref_input("assetId", &place_asset_id_ref)
-                    .add_value_input::<PlaceConfigurationModel>(
-                        "configuration",
-                        &target.clone().into(),
-                    )?
-                    .clone(),
-            );
+            if let Some(configuration) = &place.configuration {
+                resources.push(
+                    Resource::new(resource_types::PLACE_CONFIGURATION, name)
+                        .add_ref_input("assetId", &place_asset_id_ref)
+                        .add_value_input::<PlaceConfigurationModel>(
+                            "configuration",
+                            &configuration.clone().into(),
+                        )?
+                        .clone(),
+                );
+            }
         }
     } else {
         return Err("No start place defined".to_owned());
     }
 
-    if let Some(developer_products) = &target_config.products {
-        for (name, developer_product) in developer_products {
-            let product_name = developer_product
-                .name
-                .clone()
-                .ok_or(format!("Missing required field name for product {}", name))?;
-            let product_price = developer_product
-                .price
-                .ok_or(format!("Missing required field price for product {}", name))?;
-
+    if let Some(products) = &target_config.products {
+        for (name, product) in products {
             let mut product_resource = Resource::new(resource_types::DEVELOPER_PRODUCT, name)
                 .add_ref_input("experienceId", &experience_asset_id_ref)
-                .add_value_input("name", &product_name)?
-                .add_value_input("price", &product_price)?
+                .add_value_input("name", &product.name)?
+                .add_value_input("price", &product.price)?
                 .add_value_input(
                     "description",
-                    developer_product
-                        .description
-                        .as_ref()
-                        .unwrap_or(&"".to_owned()),
+                    product.description.as_ref().unwrap_or(&"".to_owned()),
                 )?
                 .clone();
-            if let Some(icon_path) = &developer_product.icon {
+            if let Some(icon_path) = &product.icon {
                 let icon_resource = Resource::new(resource_types::DEVELOPER_PRODUCT_ICON, name)
                     .add_ref_input("experienceId", &experience_asset_id_ref)
                     .add_value_input("filePath", icon_path)?
@@ -371,22 +359,13 @@ fn get_desired_experience_graph(
     }
 
     if let Some(passes) = &target_config.passes {
-        for (name, pass_config) in passes {
-            let pass_icon_file = pass_config
-                .icon
-                .clone()
-                .ok_or(format!("Missing required field icon for pass {}", name))?;
-            let pass_name = pass_config
-                .name
-                .clone()
-                .ok_or(format!("Missing required field name for pass {}", name))?;
-
+        for (name, pass) in passes {
             let pass_resource = Resource::new(resource_types::GAME_PASS, name)
                 .add_ref_input("startPlaceId", &experience_start_place_id_ref)
-                .add_value_input("name", &pass_name)?
-                .add_value_input("description", &pass_config.description)?
-                .add_value_input("price", &pass_config.price)?
-                .add_value_input("iconFilePath", &pass_icon_file)?
+                .add_value_input("name", &pass.name)?
+                .add_value_input("description", &pass.description)?
+                .add_value_input("price", &pass.price)?
+                .add_value_input("iconFilePath", &pass.icon)?
                 .clone();
             resources.push(pass_resource.clone());
             resources.push(
@@ -396,10 +375,10 @@ fn get_desired_experience_graph(
                         "initialAssetId",
                         &pass_resource.get_input_ref("initialIconAssetId"),
                     )
-                    .add_value_input("filePath", &pass_icon_file)?
+                    .add_value_input("filePath", &pass.icon)?
                     .add_value_input(
                         "fileHash",
-                        &get_file_hash(project_path.join(&pass_icon_file).as_path())?,
+                        &get_file_hash(project_path.join(&pass.icon).as_path())?,
                     )?
                     .clone(),
             )
@@ -407,22 +386,13 @@ fn get_desired_experience_graph(
     }
 
     if let Some(badges) = &target_config.badges {
-        for (name, badge_config) in badges {
-            let badge_icon_file = badge_config
-                .icon
-                .clone()
-                .ok_or(format!("Missing required field icon for pass {}", name))?;
-            let badge_name = badge_config
-                .name
-                .clone()
-                .ok_or(format!("Missing required field name for pass {}", name))?;
-
+        for (name, badge) in badges {
             let badge_resource = Resource::new(resource_types::BADGE, name)
                 .add_ref_input("experienceId", &experience_asset_id_ref)
-                .add_value_input("name", &badge_name)?
-                .add_value_input("description", &badge_config.description)?
-                .add_value_input("enabled", &badge_config.enabled.unwrap_or(true))?
-                .add_value_input("iconFilePath", &badge_icon_file)?
+                .add_value_input("name", &badge.name)?
+                .add_value_input("description", &badge.description)?
+                .add_value_input("enabled", &badge.enabled.unwrap_or(true))?
+                .add_value_input("iconFilePath", &badge.icon)?
                 .clone();
             resources.push(badge_resource.clone());
             resources.push(
@@ -432,10 +402,10 @@ fn get_desired_experience_graph(
                         "initialAssetId",
                         &badge_resource.get_input_ref("initialIconAssetId"),
                     )
-                    .add_value_input("filePath", &badge_icon_file)?
+                    .add_value_input("filePath", &badge.icon)?
                     .add_value_input(
                         "fileHash",
-                        &get_file_hash(project_path.join(&badge_icon_file).as_path())?,
+                        &get_file_hash(project_path.join(&badge.icon).as_path())?,
                     )?
                     .clone(),
             )
@@ -445,7 +415,7 @@ fn get_desired_experience_graph(
     if let Some(assets) = &target_config.assets {
         for asset_config in assets {
             let assets = match asset_config.clone() {
-                AssetConfig::File(file) => {
+                AssetTargetConfig::File(file) => {
                     let relative_to_project = project_path.join(file.clone());
                     let relative_to_project = relative_to_project
                         .to_str()
@@ -480,7 +450,7 @@ fn get_desired_experience_graph(
                     }
                     assets
                 }
-                AssetConfig::FileWithAlias { file, name } => vec![(file, name)],
+                AssetTargetConfig::FileWithAlias { file, name } => vec![(file, name)],
             };
 
             for (file, alias) in assets {


### PR DESCRIPTION
Closes #43 

This PR replaces the existing `templates` field with a new `target` field that is more extensible for future target types and also cleans up some of the hierarchy of resource types. It also makes place files optional since that is now technically possible, although a little useless.