### PR TITLE
fully support avatar experience configuration and improve configuration and activation resource lifecycles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,6 +876,7 @@ dependencies = [
  "scraper",
  "serde",
  "serde_json",
+ "serde_repr",
  "serde_yaml",
  "sha2",
  "tokio",
@@ -1936,6 +1937,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ yansi = "0.5.0"
 scraper = "0.12.0"
 url = { version = "2.2.2", features = ["serde"] }
 base64 = "0.13.0"
+serde_repr = "0.1.7"

--- a/src/resource_manager.rs
+++ b/src/resource_manager.rs
@@ -814,24 +814,12 @@ impl ResourceManager for RobloxResourceManager {
                 let outputs = serde_yaml::from_value::<ExperienceOutputs>(resource_outputs)
                     .map_err(|e| format!("Failed to deserialize outputs: {}", e))?;
 
-                self.roblox_api.configure_experience(
-                    outputs.asset_id,
-                    &ExperienceConfigurationModel {
-                        genre: None,
-                        playable_devices: None,
-                        is_friends_only: None,
-                        allow_private_servers: None,
-                        private_server_price: None,
-                        is_for_sale: None,
-                        price: None,
-                        studio_access_to_apis_allowed: None,
-                        permissions: None,
-                        universe_avatar_type: None,
-                        universe_animation_type: None,
-                        universe_collision_type: None,
-                        is_archived: Some(true),
-                    },
-                )?;
+                let model = ExperienceConfigurationModel {
+                    is_archived: true,
+                    ..Default::default()
+                };
+                self.roblox_api
+                    .configure_experience(outputs.asset_id, &model)?;
 
                 Ok(())
             }

--- a/src/resource_manager.rs
+++ b/src/resource_manager.rs
@@ -823,7 +823,17 @@ impl ResourceManager for RobloxResourceManager {
 
                 Ok(())
             }
-            resource_types::EXPERIENCE_CONFIGURATION => Ok(()),
+            resource_types::EXPERIENCE_CONFIGURATION => {
+                let inputs =
+                    serde_yaml::from_value::<ExperienceConfigurationInputs>(resource_inputs)
+                        .map_err(|e| format!("Failed to deserialize inputs: {}", e))?;
+
+                let model = ExperienceConfigurationModel::default();
+                self.roblox_api
+                    .configure_experience(inputs.experience_id, &model)?;
+
+                Ok(())
+            }
             resource_types::EXPERIENCE_ACTIVATION => {
                 let inputs = serde_yaml::from_value::<ExperienceActivationInputs>(resource_inputs)
                     .map_err(|e| format!("Failed to deserialize inputs: {}", e))?;
@@ -891,7 +901,16 @@ impl ResourceManager for RobloxResourceManager {
                 Ok(())
             }
             resource_types::PLACE_FILE => Ok(()),
-            resource_types::PLACE_CONFIGURATION => Ok(()),
+            resource_types::PLACE_CONFIGURATION => {
+                let inputs = serde_yaml::from_value::<PlaceConfigurationInputs>(resource_inputs)
+                    .map_err(|e| format!("Failed to deserialize inputs: {}", e))?;
+
+                let model = PlaceConfigurationModel::default();
+
+                self.roblox_api.configure_place(inputs.asset_id, &model)?;
+
+                Ok(())
+            }
             resource_types::SOCIAL_LINK => {
                 let inputs = serde_yaml::from_value::<SocialLinkInputs>(resource_inputs)
                     .map_err(|e| format!("Failed to deserialize inputs: {}", e))?;

--- a/src/roblox_api.rs
+++ b/src/roblox_api.rs
@@ -2,6 +2,7 @@ use multipart::client::lazy::{Multipart, PreparedFields};
 use scraper::{Html, Selector};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::{clone::Clone, collections::HashMap, ffi::OsStr, fmt, fs, path::Path};
 use ureq::{Cookie, Response};
 use url::Url;
@@ -354,6 +355,84 @@ pub struct ExperienceAvatarScales {
     pub proportion: String,
 }
 
+#[derive(Serialize_repr, Deserialize_repr, Clone)]
+#[repr(u8)]
+pub enum AssetTypeId {
+    Image = 1,
+    TShirt = 2,
+    Audio = 3,
+    Mesh = 4,
+    Lua = 5,
+    Hat = 8,
+    Place = 9,
+    Model = 10,
+    Shirt = 11,
+    Pants = 12,
+    Decal = 13,
+    Head = 17,
+    Face = 18,
+    Gear = 19,
+    Badge = 21,
+    Animation = 24,
+    Torso = 27,
+    RightArm = 28,
+    LeftArm = 29,
+    LeftLeg = 30,
+    RightLeg = 31,
+    Package = 32,
+    GamePass = 34,
+    Plugin = 38,
+    MeshPart = 40,
+    HairAccessory = 41,
+    FaceAccessory = 42,
+    NeckAccessory = 43,
+    ShoulderAccessory = 44,
+    FrontAccessory = 45,
+    BackAccessory = 46,
+    WaistAccessory = 47,
+    ClimbAnimation = 48,
+    DeathAnimation = 49,
+    FallAnimation = 50,
+    IdleAnimation = 51,
+    JumpAnimation = 52,
+    RunAnimation = 53,
+    SwimAnimation = 54,
+    WalkAnimation = 55,
+    PoseAnimation = 56,
+    EarAccessory = 57,
+    EyeAccessory = 58,
+    EmoteAnimation = 61,
+    Video = 62,
+    TShirtAccessory = 64,
+    ShirtAccessory = 65,
+    PantsAccessory = 66,
+    JacketAccessory = 67,
+    SweaterAccessory = 68,
+    ShortsAccessory = 69,
+    LeftShoeAccessory = 70,
+    RightShoeAccessory = 71,
+    DressSkirtAccessory = 72,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ExperienceAvatarAssetOverride {
+    #[serde(rename = "assetTypeID")]
+    pub asset_type_id: AssetTypeId,
+    pub is_player_choice: bool,
+    #[serde(rename = "assetID")]
+    pub asset_id: Option<AssetId>,
+}
+impl ExperienceAvatarAssetOverride {
+    pub fn player_choice(asset_type_id: AssetTypeId) -> Self {
+        Self {
+            asset_type_id,
+            is_player_choice: true,
+            asset_id: None,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct ExperiencePermissionsModel {
@@ -381,6 +460,7 @@ pub struct ExperienceConfigurationModel {
     pub universe_collision_type: ExperienceCollisionType,
     pub universe_avatar_min_scales: ExperienceAvatarScales,
     pub universe_avatar_max_scales: ExperienceAvatarScales,
+    pub universe_avatar_asset_overrides: Vec<ExperienceAvatarAssetOverride>,
 
     pub is_archived: bool,
 }
@@ -424,6 +504,19 @@ impl Default for ExperienceConfigurationModel {
                 body_type: 1.0.to_string(),
                 proportion: 1.0.to_string(),
             },
+            universe_avatar_asset_overrides: vec![
+                ExperienceAvatarAssetOverride::player_choice(AssetTypeId::Face),
+                ExperienceAvatarAssetOverride::player_choice(AssetTypeId::Head),
+                ExperienceAvatarAssetOverride::player_choice(AssetTypeId::Torso),
+                ExperienceAvatarAssetOverride::player_choice(AssetTypeId::LeftArm),
+                ExperienceAvatarAssetOverride::player_choice(AssetTypeId::RightArm),
+                ExperienceAvatarAssetOverride::player_choice(AssetTypeId::LeftLeg),
+                ExperienceAvatarAssetOverride::player_choice(AssetTypeId::RightLeg),
+                ExperienceAvatarAssetOverride::player_choice(AssetTypeId::TShirt),
+                ExperienceAvatarAssetOverride::player_choice(AssetTypeId::Shirt),
+                ExperienceAvatarAssetOverride::player_choice(AssetTypeId::Pants),
+            ],
+
             is_archived: false,
         }
     }

--- a/src/roblox_api.rs
+++ b/src/roblox_api.rs
@@ -74,19 +74,19 @@ pub struct GetPlaceResponse {
     pub max_player_count: u32,
     pub allow_copying: bool,
     pub social_slot_type: SocialSlotType,
-    pub custom_social_slots_count: u32,
+    pub custom_social_slots_count: Option<u32>,
     pub is_root_place: bool,
 }
 
 impl From<GetPlaceResponse> for PlaceConfigurationModel {
     fn from(response: GetPlaceResponse) -> Self {
         PlaceConfigurationModel {
-            name: Some(response.name),
-            description: Some(response.description),
-            max_player_count: Some(response.max_player_count),
-            allow_copying: Some(response.allow_copying),
-            social_slot_type: Some(response.social_slot_type),
-            custom_social_slot_count: Some(response.custom_social_slots_count),
+            name: response.name,
+            description: response.description,
+            max_player_count: response.max_player_count,
+            allow_copying: response.allow_copying,
+            social_slot_type: response.social_slot_type,
+            custom_social_slot_count: response.custom_social_slots_count,
         }
     }
 }
@@ -345,32 +345,88 @@ pub enum ExperienceCollisionType {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ExperienceAvatarScales {
+    pub height: String,
+    pub width: String,
+    pub head: String,
+    pub body_type: String,
+    pub proportion: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct ExperiencePermissionsModel {
-    pub is_third_party_purchase_allowed: Option<bool>,
-    pub is_third_party_teleport_allowed: Option<bool>,
+    pub is_third_party_purchase_allowed: bool,
+    pub is_third_party_teleport_allowed: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ExperienceConfigurationModel {
-    pub genre: Option<ExperienceGenre>,
-    pub playable_devices: Option<Vec<ExperiencePlayableDevice>>,
+    pub genre: ExperienceGenre,
+    pub playable_devices: Vec<ExperiencePlayableDevice>,
     pub is_friends_only: Option<bool>,
 
-    pub allow_private_servers: Option<bool>,
+    pub allow_private_servers: bool,
     pub private_server_price: Option<u32>,
-    pub is_for_sale: Option<bool>,
+    pub is_for_sale: bool,
     pub price: Option<u32>,
 
-    pub studio_access_to_apis_allowed: Option<bool>,
-    pub permissions: Option<ExperiencePermissionsModel>,
+    pub studio_access_to_apis_allowed: bool,
+    pub permissions: ExperiencePermissionsModel,
 
-    pub universe_avatar_type: Option<ExperienceAvatarType>,
-    pub universe_animation_type: Option<ExperienceAnimationType>,
-    pub universe_collision_type: Option<ExperienceCollisionType>,
+    pub universe_avatar_type: ExperienceAvatarType,
+    pub universe_animation_type: ExperienceAnimationType,
+    pub universe_collision_type: ExperienceCollisionType,
+    pub universe_avatar_min_scales: ExperienceAvatarScales,
+    pub universe_avatar_max_scales: ExperienceAvatarScales,
 
-    pub is_archived: Option<bool>,
+    pub is_archived: bool,
+}
+
+impl Default for ExperienceConfigurationModel {
+    fn default() -> Self {
+        ExperienceConfigurationModel {
+            genre: ExperienceGenre::All,
+            playable_devices: vec![
+                ExperiencePlayableDevice::Computer,
+                ExperiencePlayableDevice::Phone,
+                ExperiencePlayableDevice::Tablet,
+            ],
+            is_friends_only: Some(true),
+
+            allow_private_servers: false,
+            private_server_price: None,
+            is_for_sale: false,
+            price: None,
+
+            studio_access_to_apis_allowed: false,
+            permissions: ExperiencePermissionsModel {
+                is_third_party_purchase_allowed: false,
+                is_third_party_teleport_allowed: false,
+            },
+
+            universe_avatar_type: ExperienceAvatarType::MorphToR15,
+            universe_animation_type: ExperienceAnimationType::PlayerChoice,
+            universe_collision_type: ExperienceCollisionType::OuterBox,
+            universe_avatar_min_scales: ExperienceAvatarScales {
+                height: 0.9.to_string(),
+                width: 0.7.to_string(),
+                head: 0.95.to_string(),
+                body_type: 0.0.to_string(),
+                proportion: 0.0.to_string(),
+            },
+            universe_avatar_max_scales: ExperienceAvatarScales {
+                height: 1.05.to_string(),
+                width: 1.0.to_string(),
+                head: 1.0.to_string(),
+                body_type: 1.0.to_string(),
+                proportion: 1.0.to_string(),
+            },
+            is_archived: false,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -383,12 +439,25 @@ pub enum SocialSlotType {
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PlaceConfigurationModel {
-    pub name: Option<String>,
-    pub description: Option<String>,
-    pub max_player_count: Option<u32>,
-    pub allow_copying: Option<bool>,
-    pub social_slot_type: Option<SocialSlotType>,
+    pub name: String,
+    pub description: String,
+    pub max_player_count: u32,
+    pub allow_copying: bool,
+    pub social_slot_type: SocialSlotType,
     pub custom_social_slot_count: Option<u32>,
+}
+
+impl Default for PlaceConfigurationModel {
+    fn default() -> Self {
+        PlaceConfigurationModel {
+            name: "Untitled Game".to_owned(),
+            description: "Created with Mantle".to_owned(),
+            max_player_count: 50,
+            allow_copying: false,
+            social_slot_type: SocialSlotType::Automatic,
+            custom_social_slot_count: None,
+        }
+    }
 }
 
 pub struct RobloxApi {

--- a/src/state.rs
+++ b/src/state.rs
@@ -225,6 +225,23 @@ fn get_desired_experience_graph(
     let experience_start_place_id_ref = experience.get_input_ref("startPlaceId");
     resources.push(experience);
 
+    resources.push(
+        Resource::new(resource_types::EXPERIENCE_ACTIVATION, SINGLETON_RESOURCE_ID)
+            .add_value_input(
+                "isActive",
+                &!matches!(
+                    target_config
+                        .configuration
+                        .as_ref()
+                        .and_then(|c| c.playability)
+                        .unwrap_or(PlayabilityTargetConfig::Private),
+                    PlayabilityTargetConfig::Private
+                ),
+            )?
+            .add_ref_input("experienceId", &experience_asset_id_ref)
+            .clone(),
+    );
+
     if let Some(experience_configuration) = &target_config.configuration {
         resources.push(
             Resource::new(
@@ -237,19 +254,6 @@ fn get_desired_experience_graph(
                 &experience_configuration.into(),
             )?
             .clone(),
-        );
-
-        resources.push(
-            Resource::new(resource_types::EXPERIENCE_ACTIVATION, SINGLETON_RESOURCE_ID)
-                .add_value_input(
-                    "isActive",
-                    &!matches!(
-                        experience_configuration.playability,
-                        Some(PlayabilityTargetConfig::Private)
-                    ),
-                )?
-                .add_ref_input("experienceId", &experience_asset_id_ref)
-                .clone(),
         );
 
         if let Some(file_path) = &experience_configuration.icon {


### PR DESCRIPTION
This PR adds support for:

1. avatar scales configuration
2. avatar asset overrides configuration

This PR also modifies the behaviour for handling experience and place configuration from defaulting to `null` (i.e. no change) to having explicit default values for each field. This fixes some issues which can occur when changing between incompatible fields. This change also made some existing issues with configuration resource lifecycles which have now been addressed.