### PR TITLE
use studio roblosecurity if no env var is present

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,6 +882,7 @@ dependencies = [
  "tokio",
  "ureq",
  "url 2.2.2",
+ "winreg",
  "yansi",
 ]
 
@@ -2664,6 +2665,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ scraper = "0.12.0"
 url = { version = "2.2.2", features = ["serde"] }
 base64 = "0.13.0"
 serde_repr = "0.1.7"
+
+[target.'cfg(windows)'.dependencies]
+winreg = "0.10.1"

--- a/src/roblox_api.rs
+++ b/src/roblox_api.rs
@@ -597,7 +597,14 @@ impl RobloxApi {
         result: Result<ureq::Response, ureq::Error>,
     ) -> Result<ureq::Response, String> {
         match result {
-            Ok(response) => Ok(response),
+            Ok(response) => {
+                let url = Url::parse(response.get_url())
+                    .map_err(|e| format!("Invalid response URL: {}", e))?;
+                if matches!(url.domain(), Some("www.roblox.com")) && url.path() == "/NewLogin" {
+                    return Err("Authorization has been denied for this request.".to_owned());
+                }
+                Ok(response)
+            }
             Err(ureq::Error::Status(status, response)) => {
                 match Self::get_roblox_api_error_message(response) {
                     Some(message) => Err(message),


### PR DESCRIPTION
Closes #42 

Also fixes a bug where unauthorized `www.roblox.com` requests were considered successful because they were redirected to a 200 response (on the `/NewLogin` page).