### PR TITLE
add targetNamePrefix environment config field

### DIFF
--- a/project-fixtures/light/mantle.yml
+++ b/project-fixtures/light/mantle.yml
@@ -1,6 +1,9 @@
 environments:
   - name: staging
     branches: [dev, dev/*]
+    # targetNamePrefix:
+    #   custom: 'Test - '
+    targetNamePrefix: environmentName
 
 target:
   experience:

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -106,6 +106,15 @@ pub struct EnvironmentConfig {
     pub tag_commit: bool,
 
     pub overrides: Option<serde_yaml::Value>,
+
+    pub target_name_prefix: Option<TargetNamePrefixConfig>,
+}
+
+#[derive(Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub enum TargetNamePrefixConfig {
+    EnvironmentName,
+    Custom(String),
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/src/lib/roblox_api.rs
+++ b/src/lib/roblox_api.rs
@@ -15,6 +15,8 @@ use url::Url;
 
 use super::{roblox_auth::RobloxAuth, roblox_resource_manager::AssetId};
 
+pub const DEFAULT_PLACE_NAME: &str = "Untitled Game";
+
 #[derive(Deserialize, Debug)]
 struct RobloxApiErrorModel {
     // There are some other possible properties but we currently have no use for them so they are not
@@ -595,7 +597,7 @@ pub struct PlaceConfigurationModel {
 impl Default for PlaceConfigurationModel {
     fn default() -> Self {
         PlaceConfigurationModel {
-            name: "Untitled Game".to_owned(),
+            name: DEFAULT_PLACE_NAME.to_owned(),
             description: "Created with Mantle".to_owned(),
             max_player_count: 50,
             allow_copying: false,


### PR DESCRIPTION
adds a syntax sugar config field for overriding the target name with a prefix that is either based on the environment name or a custom value