### PR TITLE
add targetAccess environment config field

### DIFF
--- a/project-fixtures/light/mantle.yml
+++ b/project-fixtures/light/mantle.yml
@@ -1,9 +1,8 @@
 environments:
   - name: staging
     branches: [dev, dev/*]
-    # targetNamePrefix:
-    #   custom: 'Test - '
     targetNamePrefix: environmentName
+    targetAccess: private
 
 target:
   experience:

--- a/project-fixtures/light/mantle.yml
+++ b/project-fixtures/light/mantle.yml
@@ -1,6 +1,9 @@
 environments:
   - name: staging
     branches: [dev, dev/*]
+    # targetNamePrefix:
+    #   custom: 'Test - '
+    targetNamePrefix: environmentName
 
 target:
   experience:

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -108,6 +108,8 @@ pub struct EnvironmentConfig {
     pub overrides: Option<serde_yaml::Value>,
 
     pub target_name_prefix: Option<TargetNamePrefixConfig>,
+
+    pub target_access: Option<TargetAccessConfig>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -115,6 +117,14 @@ pub struct EnvironmentConfig {
 pub enum TargetNamePrefixConfig {
     EnvironmentName,
     Custom(String),
+}
+
+#[derive(Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub enum TargetAccessConfig {
+    Public,
+    Private,
+    Friends,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -274,7 +284,7 @@ pub enum AssetTargetConfig {
     FileWithAlias { file: String, name: String },
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ExperienceTargetConfigurationConfig {
     // basic info
@@ -449,7 +459,7 @@ pub struct PlaceTargetConfig {
     pub configuration: Option<PlaceTargetConfigurationConfig>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PlaceTargetConfigurationConfig {
     pub name: Option<String>,

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -106,6 +106,15 @@ pub struct EnvironmentConfig {
     pub tag_commit: bool,
 
     pub overrides: Option<serde_yaml::Value>,
+
+    pub target_name_prefix: Option<TargetNamePrefixConfig>,
+}
+
+#[derive(Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub enum TargetNamePrefixConfig {
+    EnvironmentName,
+    Custom(String),
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/src/lib/project.rs
+++ b/src/lib/project.rs
@@ -4,8 +4,9 @@ use yansi::Paint;
 
 use super::{
     config::{
-        Config, EnvironmentConfig, ExperienceTargetConfig, OwnerConfig, PaymentsConfig,
-        StateConfig, TargetConfig, TargetNamePrefixConfig,
+        Config, EnvironmentConfig, ExperienceTargetConfig, ExperienceTargetConfigurationConfig,
+        OwnerConfig, PaymentsConfig, PlaceTargetConfigurationConfig, PlayabilityTargetConfig,
+        StateConfig, TargetAccessConfig, TargetConfig, TargetNamePrefixConfig,
     },
     logger,
     resource_graph::ResourceGraph,
@@ -104,8 +105,30 @@ fn get_target_config(
                                 None => DEFAULT_PLACE_NAME.to_owned(),
                             };
                             config.name = Some(format!("{}{}", name_prefix, name));
+                        } else {
+                            place.configuration = Some(PlaceTargetConfigurationConfig {
+                                name: Some(format!("{}{}", name_prefix, DEFAULT_PLACE_NAME)),
+                                ..Default::default()
+                            })
                         }
                     }
+                }
+            }
+
+            // Apply the access to all places in the experience
+            if let Some(target_access) = environment.target_access {
+                let playability = Some(match target_access {
+                    TargetAccessConfig::Public => PlayabilityTargetConfig::Public,
+                    TargetAccessConfig::Private => PlayabilityTargetConfig::Private,
+                    TargetAccessConfig::Friends => PlayabilityTargetConfig::Friends,
+                });
+                if let Some(config) = &mut experience.configuration {
+                    config.playability = playability
+                } else {
+                    experience.configuration = Some(ExperienceTargetConfigurationConfig {
+                        playability,
+                        ..Default::default()
+                    });
                 }
             }
 

--- a/src/lib/roblox_api.rs
+++ b/src/lib/roblox_api.rs
@@ -15,6 +15,8 @@ use url::Url;
 
 use super::{roblox_auth::RobloxAuth, roblox_resource_manager::AssetId};
 
+pub const DEFAULT_PLACE_NAME: &str = "Untitled Game";
+
 #[derive(Deserialize, Debug)]
 struct RobloxApiErrorModel {
     // There are some other possible properties but we currently have no use for them so they are not
@@ -595,7 +597,7 @@ pub struct PlaceConfigurationModel {
 impl Default for PlaceConfigurationModel {
     fn default() -> Self {
         PlaceConfigurationModel {
-            name: "Untitled Game".to_owned(),
+            name: DEFAULT_PLACE_NAME.to_owned(),
             description: "Created with Mantle".to_owned(),
             max_player_count: 50,
             allow_copying: false,


### PR DESCRIPTION
adds a syntax sugar config field for overriding the target's access (playability config for experiences)

