### PR TITLE
unify state management and local state key config

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -112,11 +112,10 @@ fn get_app() -> App<'static, 'static> {
                                 .help("The Mantle project: either the path to a directory containing a 'mantle.yml' file or the path to a configuration file. Defaults to the current directory.")
                                 .takes_value(true))
                         .arg(
-                            Arg::with_name("output")
-                                .long("output")
-                                .short("o")
-                                .help("A file path to save the state file to. Defaults to `<PROJECT_DIR>/.mantle-state.yml`.")
-                                .value_name("FILE")
+                            Arg::with_name("key")
+                                .long("key")
+                                .help("A key to prefix the name of the state file (e.g. `--key custom` will result in `custom.mantle-state.yml`).")
+                                .value_name("KEY")
                                 .takes_value(true))
                 )
                 .subcommand(
@@ -128,9 +127,10 @@ fn get_app() -> App<'static, 'static> {
                                 .help("The Mantle project: either the path to a directory containing a 'mantle.yml' file or the path to a configuration file. Defaults to the current directory.")
                                 .takes_value(true))
                         .arg(
-                            Arg::with_name("FILE")
-                                .index(2)
-                                .help("A file path to a state file to upload. Defaults to `<PROJECT_DIR>/.mantle-state.yml`.")
+                            Arg::with_name("key")
+                                .long("key")
+                                .help("The prefix of the name of the state file (e.g. `--key custom` will load from `custom.mantle-state.yml`).")
+                                .value_name("KEY")
                                 .takes_value(true))
                 )
         )
@@ -176,14 +176,14 @@ pub async fn run_with(args: Vec<String>) -> i32 {
             ("download", Some(download_matches)) => {
                 commands::download::run(
                     download_matches.value_of("PROJECT"),
-                    download_matches.value_of("output"),
+                    download_matches.value_of("key"),
                 )
                 .await
             }
             ("upload", Some(upload_matches)) => {
                 commands::upload::run(
                     upload_matches.value_of("PROJECT"),
-                    upload_matches.value_of("FILE"),
+                    upload_matches.value_of("key"),
                 )
                 .await
             }

--- a/src/commands/upload.rs
+++ b/src/commands/upload.rs
@@ -6,7 +6,7 @@ use rbx_mantle::{
     state::{get_state_from_source, save_state},
 };
 
-pub async fn run(project: Option<&str>, file: Option<&str>) -> i32 {
+pub async fn run(project: Option<&str>, key: Option<&str>) -> i32 {
     logger::start_action("Upload state file:");
     let (project_path, config) = match load_project_config(project) {
         Ok(v) => v,
@@ -16,13 +16,15 @@ pub async fn run(project: Option<&str>, file: Option<&str>) -> i32 {
         }
     };
 
-    if matches!(config.state, StateConfig::Local) {
+    if !matches!(config.state, StateConfig::Remote(_)) {
         logger::end_action(Paint::red("Project is not configured with remote state"));
         return 1;
     }
 
-    let state_config = match file {
-        Some(file) => StateConfig::LocalCustom(file.to_owned()),
+    let state_config = match key {
+        Some(key) => StateConfig::LocalKey {
+            key: key.to_owned(),
+        },
         None => StateConfig::Local,
     };
     let state = match get_state_from_source(&project_path, state_config).await {

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -91,10 +91,17 @@ pub struct Config {
     /// | Value              | Description                                                                                                                                                                                                           |
     /// |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
     /// | `'local'`          | Mantle will save and load its state to and from a local `.mantle-state.yml` file.                                                                                                                                     |
+    /// | `local: <config>`  | Mantle will save and load its state to and from a local file using the provided key with the format `<key>.mantle-state.yml`.                                                                                         |
     /// | `remote: <config>` | Mantle will save and load its state to and from a remote file stored in a cloud provider. Currently the only supported provider is Amazon S3. For more information, see the [Remote State](/docs/remote-state) guide. |
     ///
     /// ```yml title="Local State Example (Default)"
     /// state: local
+    /// ```
+    ///
+    /// ```yml title="Custom Local State Example"
+    /// state:
+    ///   local:
+    ///     key: pirate-wars
     /// ```
     ///
     /// ```yml title="Remote State Example"
@@ -136,15 +143,13 @@ impl default::Default for PaymentsConfig {
 #[derive(JsonSchema, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum StateConfig {
-    LocalCustom(String),
+    #[serde(rename = "local")]
+    LocalKey {
+        /// The key to use to store your state file. The file will be named with the format
+        /// `<key>.mantle-state.yml`.
+        key: String,
+    },
     Local,
-    /// ```yml title="Remote State Example"
-    /// state:
-    ///   remote:
-    ///     region: us-west-1
-    ///     bucket: my-mantle-states
-    ///     key: pirate-wars
-    /// ```
     Remote(RemoteStateConfig),
 }
 impl default::Default for StateConfig {

--- a/src/lib/state/mod.rs
+++ b/src/lib/state/mod.rs
@@ -864,7 +864,7 @@ pub async fn save_state(
 
     match state_config {
         StateConfig::Local => save_state_to_file(project_path, &data, None),
-        StateConfig::LocalKey { key } => save_state_to_file(project_path, &data, Some(&key)),
+        StateConfig::LocalKey { key } => save_state_to_file(project_path, &data, Some(key)),
         StateConfig::Remote(config) => save_state_to_remote(config, &data).await,
     }
 }


### PR DESCRIPTION
Closes #113 and reworks #112. Now local state files are managed with just a `key` which is used as the file prefix in the same way remote state files are. `mantle state download` and `mantle state upload` now accept a unified `--key` arg for this, and the config format now looks like:

```yml
state:
  local:
    key: custom
```