### PR TITLE
fix(mantle,rbx_api): replace deprecated alias endpoints

### DIFF
--- a/mantle/rbx_api/src/asset_aliases/mod.rs
+++ b/mantle/rbx_api/src/asset_aliases/mod.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 use crate::{
     errors::RobloxApiResult,
     helpers::{handle, handle_as_json},
-    models::{AssetId, AssetTypeId},
+    models::AssetId,
     RobloxApi,
 };
 
@@ -47,11 +47,11 @@ impl RobloxApi {
             .client
             .post("https://apis.roblox.com/content-aliases-api/v1/universes/update-alias")
             .query(&[
-                ("universeId", &experience_id.to_string()),
-                ("oldName", &previous_name),
-                ("name", &name),
-                ("type", &AssetTypeId::Image.to_string()),
-                ("targetId", &asset_id.to_string()),
+                ("universeId", experience_id.to_string().as_str()),
+                ("oldName", previous_name.as_str()),
+                ("name", name.as_str()),
+                ("type", "1"),
+                ("targetId", asset_id.to_string().as_str()),
             ]);
 
         handle(req).await?;
@@ -82,7 +82,7 @@ impl RobloxApi {
     ) -> RobloxApiResult<ListAssetAliasesResponse> {
         let req = self
             .client
-            .get("https://api.roblox.com/universes/get-aliases")
+            .get("https://apis.roblox.com/content-aliases-api/v1/universes/get-aliases")
             .query(&[
                 ("universeId", &experience_id.to_string()),
                 ("page", &page.to_string()),

--- a/mantle/rbx_api/src/asset_aliases/mod.rs
+++ b/mantle/rbx_api/src/asset_aliases/mod.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 use crate::{
     errors::RobloxApiResult,
     helpers::{handle, handle_as_json},
-    models::AssetId,
+    models::{AssetId, AssetTypeId},
     RobloxApi,
 };
 
@@ -45,16 +45,14 @@ impl RobloxApi {
     ) -> RobloxApiResult<()> {
         let req = self
             .client
-            .post("https://api.roblox.com/universes/update-alias-v2")
+            .post("https://apis.roblox.com/content-aliases-api/v1/universes/update-alias")
             .query(&[
                 ("universeId", &experience_id.to_string()),
                 ("oldName", &previous_name),
-            ])
-            .json(&json!({
-                "name": name,
-                "type": "1",
-                "targetId": asset_id,
-            }));
+                ("name", &name),
+                ("type", &AssetTypeId::Image.to_string()),
+                ("targetId", &asset_id.to_string()),
+            ]);
 
         handle(req).await?;
 
@@ -68,7 +66,7 @@ impl RobloxApi {
     ) -> RobloxApiResult<()> {
         let req = self
             .client
-            .post("https://api.roblox.com/universes/delete-alias")
+            .post("https://apis.roblox.com/content-aliases-api/v1/universes/delete-alias")
             .header(header::CONTENT_LENGTH, 0)
             .query(&[("universeId", &experience_id.to_string()), ("name", &name)]);
 


### PR DESCRIPTION
Resolves final endpoints affected by the deprecation of `api.roblox.com` ([see thread for details](https://devforum.roblox.com/t/sunsetting-apirobloxcom-on-may-22-2023/2324429)).