### PR TITLE
fix(mantle,rbx_api): fix import badges and notifications bugs

### DIFF
--- a/mantle/rbx_api/src/badges/models.rs
+++ b/mantle/rbx_api/src/badges/models.rs
@@ -21,7 +21,7 @@ pub struct ListBadgesResponse {
 pub struct ListBadgeResponse {
     pub id: AssetId,
     pub name: String,
-    pub description: String,
+    pub description: Option<String>,
     pub icon_image_id: AssetId,
     pub enabled: bool,
 }

--- a/mantle/rbx_api/src/notifications/mod.rs
+++ b/mantle/rbx_api/src/notifications/mod.rs
@@ -98,8 +98,10 @@ impl RobloxApi {
                 .await?;
             all_notifications.extend(res.notification_string_configs);
 
-            if res.next_page_cursor.is_none() {
-                break;
+            match res.next_page_cursor {
+                None => break,
+                Some(next_page_cursor) if next_page_cursor.is_empty() => break,
+                _ => {}
             }
 
             page_cursor = res.next_page_cursor;

--- a/mantle/rbx_mantle/src/state/mod.rs
+++ b/mantle/rbx_mantle/src/state/mod.rs
@@ -753,7 +753,7 @@ pub async fn import_graph(
             &format!("badge_{}", badge.id),
             RobloxInputs::Badge(BadgeInputs {
                 name: badge.name,
-                description: badge.description,
+                description: badge.description.unwrap_or_default(),
                 enabled: badge.enabled,
                 icon_file_path: "fake-path".to_owned(),
             }),


### PR DESCRIPTION
Fixes bugs with imports:

* The badge `description` may be `null`
* The notifications `next_page_cursor` may be an empty string when reaching the final page