### PR TITLE
chore(rbx_cookie): put CLI dependencies behind feature flag

### DIFF
--- a/mantle/rbx_cookie/Cargo.toml
+++ b/mantle/rbx_cookie/Cargo.toml
@@ -7,7 +7,11 @@ homepage = "https://github.com/blake-mealey/mantle/tree/main/rbx_cookie"
 repository = "https://github.com/blake-mealey/mantle"
 authors = ["Blake Mealey <blakemealey@gmail.com>"]
 license = "MIT"
-include = ["src", "Cargo.toml", "README.md"]
+include = [
+    "src",
+    "Cargo.toml",
+    "README.md"
+]
 
 [features]
 default = ["cli"]

--- a/mantle/rbx_cookie/Cargo.toml
+++ b/mantle/rbx_cookie/Cargo.toml
@@ -7,18 +7,18 @@ homepage = "https://github.com/blake-mealey/mantle/tree/main/rbx_cookie"
 repository = "https://github.com/blake-mealey/mantle"
 authors = ["Blake Mealey <blakemealey@gmail.com>"]
 license = "MIT"
-include = [
-    "src",
-    "Cargo.toml",
-    "README.md"
-]
+include = ["src", "Cargo.toml", "README.md"]
+
+[features]
+default = ["cli"]
+cli = ["dep:clap", "dep:env_logger"]
 
 [dependencies]
 cookie = "0.15.1"
 dirs = "1.0.4"
 log = "0.4.14"
-env_logger = "0.9.0"
-clap = "2.33.0"
+env_logger = { version = "0.9.0", optional = true }
+clap = { version = "2.33.0", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.10.1"


### PR DESCRIPTION
This PR puts the `clap` and `env_logger` dependencies of `rbx_cookie` behind a new feature flag named `cli`, which is enabled by default. This will let library consumers of `rbx_cookie` disable the CLI-specific dependencies as such:

```toml
[dependencies]
rbx_cookie = { version = "x.y.z", default-features = false }
```

Fixes https://github.com/blake-mealey/mantle/issues/192