### PR TITLE
feat(mantle): support container and instance metadata AWS credential providers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - "v*.*.*"
+      - 'v*.*.*'
 
 jobs:
   windows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 
 jobs:
   windows:

--- a/docs/site/pages/docs/authentication.mdx
+++ b/docs/site/pages/docs/authentication.mdx
@@ -1,11 +1,10 @@
-import { Callout, Tabs, Tab } from 'nextra-theme-docs';
+import { Callout, Tabs, Tab } from "nextra-theme-docs";
 
 # Authentication
 
 <Callout type="error">
-  Remember to never save your secrets in source control or any insecure
-  environment. Anybody who gets access to them could use them to steal your
-  accounts.
+  Remember to never save your secrets in source control or any insecure environment. Anybody who
+  gets access to them could use them to steal your accounts.
 </Callout>
 
 ## Resource management
@@ -111,6 +110,10 @@ getting your AWS credentials](https://docs.aws.amazon.com/general/latest/gr/aws-
 The simplest method is to set the `MANTLE_AWS_ACCESS_KEY_ID` and `MANTLE_AWS_SECRET_ACCESS_KEY` environment
 variables. Mantle also supports the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` variables but recommends
 you scope your variables to Mantle to avoid conflicts with other tools.
+
+If you're using Mantle within an AWS EC2 instance or AWS Elastic Container Service, you can set the
+`MANTLE_AWS_INHERIT_IAM_ROLE` environment variable to `true` to inherit the permission set granted to the host
+runner via either the EC2 instance's IAM role or the Elastic Container Service task execution IAM role.
 
 You can set your environment variables in various ways, like the following:
 

--- a/mantle/rbx_mantle/src/state/aws_credentials_provider.rs
+++ b/mantle/rbx_mantle/src/state/aws_credentials_provider.rs
@@ -17,31 +17,32 @@ pub struct AwsCredentialsProvider {
 
 impl AwsCredentialsProvider {
     pub fn new() -> AwsCredentialsProvider {
-        let mut all_providers = AwsCredentialsProvider {
-            prefixed_environment_provider: EnvironmentProvider::with_prefix("MANTLE_AWS"),
-            environment_provider: EnvironmentProvider::default(),
-            profile_provider: ProfileProvider::new().ok(),
-            container_provider: None,
-            instance_metadata_provider: None,
-        };
-
+        let mut inherit_iam_role = false;
         if let Ok(value) = env::var("MANTLE_AWS_INHERIT_IAM_ROLE") {
             if value == "true" {
-                all_providers.container_provider = Some(ContainerProvider::new());
-                all_providers
-                    .container_provider
-                    .expect("ContainerProvider should be initialized")
-                    .set_timeout(Duration::from_secs(15));
-
-                all_providers.instance_metadata_provider = Some(InstanceMetadataProvider::new());
-                all_providers
-                    .instance_metadata_provider
-                    .expect("InstanceMetadataProvider should be initialized")
-                    .set_timeout(Duration::from_secs(15));
+                inherit_iam_role = true;
             }
         }
 
-        return all_providers;
+        AwsCredentialsProvider {
+            prefixed_environment_provider: EnvironmentProvider::with_prefix("MANTLE_AWS"),
+            environment_provider: EnvironmentProvider::default(),
+            profile_provider: ProfileProvider::new().ok(),
+            container_provider: if inherit_iam_role {
+                let mut provider = ContainerProvider::new();
+                provider.set_timeout(Duration::from_secs(15));
+                Some(provider)
+            } else {
+                None
+            },
+            instance_metadata_provider: if inherit_iam_role {
+                let mut provider = InstanceMetadataProvider::new();
+                provider.set_timeout(Duration::from_secs(15));
+                Some(provider)
+            } else {
+                None
+            },
+        }
     }
 }
 
@@ -59,11 +60,15 @@ async fn chain_provider_credentials(
             return Ok(creds);
         }
     }
-    if let Ok(creds) = provider.container_provider.credentials().await {
-        return Ok(creds);
+    if let Some(ref container_provider) = provider.container_provider {
+        if let Ok(creds) = container_provider.credentials().await {
+            return Ok(creds);
+        }
     }
-    if let Ok(creds) = provider.instance_metadata_provider.credentials().await {
-        return Ok(creds);
+    if let Some(ref instance_metadata_provider) = provider.instance_metadata_provider {
+        if let Ok(creds) = instance_metadata_provider.credentials().await {
+            return Ok(creds);
+        }
     }
     Err(CredentialsError::new(
         "Couldn't find AWS credentials in environment, credentials file, or instance/container IAM role.",


### PR DESCRIPTION
This pull adds support for ECS container and EC2 instance metadata credential loading so that keys don't have to be explicitly defined for deployment targets.

Tested in ECS and it works great! Haven't tested with EC2 but it should work the same.

Resolves #201 

Side note: Could we get a patch version bump with this update so I can use this change with Aftman instead of using the forked repo?