### PR TITLE
New Id type for better type safeguard. agrenst using wrong Id to call a function

### DIFF
--- a/mantle/rbx_api/src/groups/mod.rs
+++ b/mantle/rbx_api/src/groups/mod.rs
@@ -5,7 +5,7 @@ use serde_json::json;
 use crate::{
     errors::RobloxApiResult,
     helpers::{handle, handle_as_json},
-    models::AssetId,
+    models::{AssetId, Group, Id},
     RobloxApi,
 };
 
@@ -13,9 +13,9 @@ use self::models::ListGroupRolesResponse;
 
 impl RobloxApi {
     /// * `role_id` - Not the same as rank, must be retrieved using [`RobloxApi::list_group_roles`]
-    pub async fn update_user_group_role(
+    pub async fn update_user_group_role<GroupId: Into<Id<Group>>>(
         &self,
-        group_id: AssetId,
+        group_id: GroupId,
         user_id: AssetId,
         role_id: u64,
     ) -> RobloxApiResult<()> {
@@ -23,7 +23,8 @@ impl RobloxApi {
             .client
             .patch(format!(
                 "https://groups.roblox.com/v1/groups/{}/users/{}",
-                group_id, user_id
+                group_id.into(),
+                user_id
             ))
             .json(&json!({ "roleId": role_id }));
 
@@ -32,13 +33,13 @@ impl RobloxApi {
         Ok(())
     }
 
-    pub async fn list_group_roles(
+    pub async fn list_group_roles<GroupId: Into<Id<Group>>>(
         &self,
-        group_id: AssetId,
+        group_id: GroupId,
     ) -> RobloxApiResult<ListGroupRolesResponse> {
         let req = self.client.get(format!(
             "https://groups.roblox.com/v1/groups/{}/roles",
-            group_id
+            group_id.into()
         ));
 
         handle_as_json(req).await

--- a/mantle/rbx_api/src/groups/models.rs
+++ b/mantle/rbx_api/src/groups/models.rs
@@ -1,18 +1,18 @@
 use serde::Deserialize;
 
-use crate::models::AssetId;
+use crate::models::{Group, Id, Role};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ListGroupRolesResponse {
-    pub group_id: AssetId,
+    pub group_id: Id<Group>,
     pub roles: Vec<ListGroupRolesResponseItem>,
 }
 
 #[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ListGroupRolesResponseItem {
-    pub id: u64,
+    pub id: Id<Role>,
     pub name: String,
     pub description: Option<String>,
     pub rank: u32,

--- a/mantle/rbx_api/src/models.rs
+++ b/mantle/rbx_api/src/models.rs
@@ -1,4 +1,4 @@
-use std::{clone::Clone, fmt, str};
+use std::{clone::Clone, fmt, marker::PhantomData, str};
 
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -99,4 +99,49 @@ pub enum SocialSlotType {
 #[serde(rename_all = "camelCase")]
 pub struct UploadImageResponse {
     pub target_id: AssetId,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+pub struct Group;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+pub struct Role;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+pub struct Id<T> {
+    id: AssetId,
+    marker: PhantomData<T>,
+}
+
+impl<T> Id<T> {
+    pub fn new(primitive: AssetId) -> Self {
+        Id {
+            id: primitive,
+            marker: PhantomData,
+        }
+    }
+
+    pub fn into_inner(self) -> AssetId {
+        self.id
+    }
+    
+}
+impl<T> From<AssetId> for Id<T> {
+    fn from(id: AssetId) -> Self {
+        Self::new(id)
+    }
+}
+impl<T> From<Option<AssetId>> for Id<T> {
+    fn from(id: Option<AssetId>) -> Self {
+        Self::new(id.unwrap())
+    }
+}
+
+//required for `std::option::Option<u64>` to implement `Into<std::option::Option<Id<rbx_api::models::Group>>>`
+
+impl<T> fmt::Display for Id<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let inner = self.id;
+        fmt::Display::fmt(&inner, f)
+    }
 }


### PR DESCRIPTION
 Current PR is an example version if the maintainer wants the change I will continue with this PR
 
 ### What does it do?
Adds a ID type currently with only 2 valid IDs
- Group
- Rank
This causes the Id<Rank> value not to be usable in anyting what expect a Id<Group>

I call into on whatever the function gets so you can give it a u64 and it will auto convert it to a Id<Group>

### Why is it needed?

To make the api better. 

### Reason to say no to this.
This will add extra complexity to the codebase the question in the end is the extra complexity worth it for the added saveguard?

This is a breaking chance since we change the input and output types.

